### PR TITLE
Add base template

### DIFF
--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 from django.urls import path
 
-from pocket.views import FooterView
+from pocket.views import BaseView
 
 urlpatterns = [
-    path('', FooterView.as_view()),
+    path('', BaseView.as_view()),
 ]

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.views.generic import TemplateView
-class FooterView(TemplateView):
-    template_name = "footer.html"
+class BaseView(TemplateView):
+    template_name = "base.html"
 
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,29 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="{% static '/css/home.css' %}">
+    <link rel="stylesheet" href="{% static '/css/picto.css' %}">
+    <link rel="stylesheet" href="{% static '/css/split.css' %}">
+    {% block head_css %}
+    {% endblock head_css%}
+    <title>Devket</title>
+</head>
+<body>
+    <!-- HEADER -->
+    {% include 'header.html' %}
+
+    <!-- MAIN -->
+    <main>
+        {% block content %}
+        {% endblock content%}      
+    </main>
+
+    <!-- FOOTER -->
+    {% include 'footer.html' %}
+</body>
+</html>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,11 +1,4 @@
 {% load static %}
-
-<link rel="stylesheet" href="{% static '/css/home.css' %}">
-<link rel="stylesheet" href="{% static '/css/picto.css' %}">
-<link rel="stylesheet" href="{% static '/css/split.css' %}">
-{% block head_css %}
-{% endblock head_css%}
-
 <!-- FOOTER -->
 <footer class="platform-footer">
     <nav class="footer-navigation">

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,11 +1,4 @@
 {% load static %}
-
-<link rel="stylesheet" href="{% static '/css/home.css' %}">
-<link rel="stylesheet" href="{% static '/css/picto.css' %}">
-<link rel="stylesheet" href="{% static '/css/split.css' %}">
-{% block head_css %}
-{% endblock head_css%}
-
 <!-- HEADER  -->
 <header class="pocket-header platform header">
     <nav class="platform-header">


### PR DESCRIPTION
## What about is this PR? 🔍
- Template tag를 이용하여 분리한 footer.html과 header.html을 include를 통해 base.html화면으로 이동하며 불러올수 있도록 수정
- footer.html과 header.html에 import했던 css파일은 base.html의 css와 중복되지 않게 제거

<br>

## Change Logic 📝

### before
- urls.py와 views.py를 base.html로 이동될 수 있게 수정
### after
- urls.py와 views.py를 base.html로 이동될 수 있게 수정
<br>

## To Reviewers 👂
- 기본 이동 화면이 home.html으로 이동될 수 있게 urls.py와 views.py가 변경될 예정입니다.

<br>

## Screenshot 📷
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/103980058/199983775-39ddd90f-d98d-4d54-ba85-bc84b65a51ba.png">


<br>