### PR TITLE
Add home template and mapping url and template

### DIFF
--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 from django.urls import path
 
-from pocket.views import BaseView
+from pocket.views import HomeView
 
 urlpatterns = [
-    path('', BaseView.as_view()),
+    path('', HomeView.as_view()),
 ]

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.views.generic import TemplateView
-class BaseView(TemplateView):
-    template_name = "base.html"
+class HomeView(TemplateView):
+    template_name = "common/home.html"
 
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)

--- a/templates/common/home.html
+++ b/templates/common/home.html
@@ -1,0 +1,97 @@
+
+{% extends "base.html" %}
+{% load static%}
+{% block content %}
+<!-- MAIN -->
+<div class="pocket-homepage mzp-t-content-xl">
+    <section class="mzp-c-split pocket-homepage-header mzp-l-split-pop">
+        <div class="mzp-c-split-container">
+            <div class="mzp-c-split-body">
+                <div class="c-hero-badge">
+                    <div class="mzp-c-logo mzp-t-logo-xs mzp-t-product-pocket"></div>
+                    <p><strong>Pocket의 10년</strong></p>
+                </div>
+                <h1 class="section-heading">나만의</br>콘텐츠 라이브러리</h1>
+                <p class="section-lede">나만의 온라인 서재에서 양질의 아티클을 만나보세요.</p>
+                <div class="pocket-homepage-accounts">
+                    <a href="#" class="mzp-c-button">Pocket 가입하기</a>
+                    <p class="pocket-homepage-mobile-login">계정이 이미 있으십니까?
+                    <a href="">로그인</a>
+                    </p>
+                </div>
+            </div>
+            <div class="mzp-c-split-media mzp-l-split-media-overflow">
+                <img src="/static/images/home/pocket-home-articles.c31e77095a9a.png" alt="" class="mzp-c-split-media-asset" loading="eager" />
+            </div>
+        </div>
+    </section>
+    <section class="mzp-c-split mzp-l-split-center-on-sm-md mzp-l-split-reversed">
+        <div class="mzp-c-split-container">
+            <div class="mzp-c-split-body">
+            <h2 class="sub-section-heading">흥미로운 스토리는 일단 저장 후 확인은 내가 원할 때 언제든지.</h2>
+            <p class="section-lede">나중에 다시 보고 싶은 콘텐츠가 있나요? 이제 메신저로 내가 나에게 링크를 보내지 않아도 돼요! 장문의 기사나 인터뷰, 사설, 레시피까지 나중에 다시
+                보고 싶은 흥미로운 콘텐츠를 발견했다면 브라우저의 <span class=pocket-logo-inline>Pocket 저장</span> 버튼을 클릭하거나 Pocket 앱을 통해 나만의
+                Pocket 라이브러리에 저장해 보세요.</p>
+            </div>
+            <div class="mzp-c-split-media mzp-l-split-h-center">
+                <img src="/static/images/home/pocket-colorful-books.026516da6bc5.svg" alt="" class="mzp-c-split-media-asset" />
+            </div>
+        </div>
+    </section>
+    <section class="mzp-c-split mzp-l-split-center-on-sm-md">
+        <div class="mzp-c-split-container">
+            <div class="mzp-c-split-body">
+                <h2 class="sub-section-heading">아티클 추천 기능</h2>
+                <p class="section-lede">새로운 관점, 흥미로운 주제 탐구, 시대를 막론한 클래식 등, 최고의 아티클을 추천합니다. 읽어 볼 가치가 충분한 양질의 아티클을 마음껏 즐겨보세요.
+                </p>
+            </div>
+            <div class="mzp-c-split-media mzp-l-split-h-center">
+                <img src="static/images/home/pocket-list-mobile.8316f5977cf6.png" alt="" class="mzp-c-split-media-asset" />
+            </div>
+        </div>
+    </section>
+    <section class="pocket-homepage-picto mzp-l-content mzp-t-content-xl">
+        <h2 class="sub-section-heading">다양한 커스텀 옵션으로 즐기는 Pocket</h2>
+        <ul class="mzp-l-columns mzp-t-columns-three">
+            <div class="mzp-c-picto">
+                <img src="/static/images/home/pocket-text-icon.b3b602691e01.svg" alt="" class="mzp-c-picto-image" width="40" />
+                <h3 class="mzp-c-picto-heading">텍스트 크기, 폰트 스타일, 읽기 모드 등을 맞춤 설정하여 쾌적한 읽기 환경을 만들어 보세요.</h3>
+            </div>
+            <div class="mzp-c-picto">
+                <img src="/static/images/home/pocket-tag-icon.384b16fcb98f.svg" alt="" class="mzp-c-picto-image" width="40" />
+                <h3 class="mzp-c-picto-heading">저장된 콘텐츠를 태그로 분류하고, 중요한 내용은 하이라이트로 표시해 보세요.</h3>
+            </div>
+            <div class="mzp-c-picto">
+                <img src="/static/images/home/pocket-audio-icon.a1b5c8915d82.svg" alt="" class="mzp-c-picto-image" width="40" />
+                <h3 class="mzp-c-picto-heading">오디오 재생 옵션을 이용해 Pocket 앱에서 아티클을 오디오로 즐겨 보세요.</h3>
+            </div>
+        </ul>
+    </section>
+    <section class="pocket-homepage-premium ">
+        <div class="mzp-l-content mzp-t-content-xl">
+            <div class="mzp-l-columns mzp-t-columns-two">
+                <div>
+                    <h2>Pocket의 프리미엄 기능</h2>
+                    <p>Pocket Premium에서는 광고 없는 쾌적한 환경에서 내가 원하는 페이스로 스토리에 온전히 집중할 수 있습니다. 프리미엄 계정의 혜택은 다음과 같습니다.</p>
+                </div>
+                <div>
+                    <ul class="mzp-u-list-styled">
+                        <li>저장한 콘텐츠의 영구 라이브러리(해당 콘텐츠가 웹에서 삭제된 경우에도 계속 이용 가능)</li>
+                        <li>권장 태그</li>
+                        <li>전문 검색</li>
+                        <li>무제한 하이라이트</li>
+                        <li>프리미엄 폰트</li>
+                    </ul>
+                    <a href="#" class="mzp-c-button">Pocket Premium 다운로드하기</a>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="pocket-homepage-bottom mzp-l-content">
+        <h2 class="sub-section-heading">웹에서 발견한 흥미진진한 콘텐츠를 쉽고 간편하게 저장하세요</h2>
+        <div class="pocket-homepage-button-center">
+            <a href="#" class="mzp-c-button">Pocket 가입하기</a>
+        </div>
+    </section>
+</div>
+{% endblock content%}


### PR DESCRIPTION
## What about is this PR? 🔍
- Template tag를 이용하여 footer와 header를 base.html에서 include, home.html을 base.html의 content 영역에서 조회
- urls.py와 views.py는 path(/) 기본이 home이 될 수 있게 설정


<br>

## Change Logic 📝
### before
- urls.py와 views.py를 base로 이동하는 코드 설정

### after
- urls.py와 views.py를 home으로 이동할 수 있는 코드 설정

<br>

## To Reviewers 👂
- home 화면 추가하였고 로그인, 회원가입, 결제, 비밀번호 찾기 등의 template을 차례로 올릴 예정입니다.


<br>

## Screenshot 📷
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/103980058/199997454-eda2381c-9a28-4e59-9537-9ac292408fb6.png">
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/103980058/199997516-5abf4c6b-f9fd-476d-90bc-ab557a06fe66.png">
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/103980058/199997567-0a8b52d4-0216-4eeb-9e4a-a7708f840a44.png">
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/103980058/199997620-f311f276-048e-4c5d-a62a-9cd9dd439cf8.png">




<br>