### PR TITLE
FEAT: Rendering mylist view and bottom-toolbar under each item 

### DIFF
--- a/static/css/mylist/base.css
+++ b/static/css/mylist/base.css
@@ -1475,5 +1475,4 @@ header + .cmg9k0j {
     font-style: italic;
     font-size: var(--fontSize085)
 }
-/*# sourceMappingURL=5ba18fb47aff7d05.css.map*/
 

--- a/static/css/mylist/body.css
+++ b/static/css/mylist/body.css
@@ -1,0 +1,1431 @@
+.c97c5c {
+    --aspect-percent: 56.25%;
+    position: relative;
+    border-radius: var(--size025);
+    overflow: hidden;
+    padding-bottom: 1rem
+}
+
+.side-by-side .c97c5c {
+    --aspect-percent: 75%
+}
+
+.side-by-side .c97c5c .no-link {
+    padding-bottom: 66%
+}
+
+.c97c5c .no-link,
+.c97c5c a {
+    position: relative;
+    display: block;
+    /* width: 100%; */
+    padding-bottom: var(--aspect-percent);
+    /* height: 0; */
+    overflow: hidden
+}
+
+.c97c5c .no-image,
+.c97c5c img {
+    position: absolute;
+    -o-object-fit: cover;
+    object-fit: cover;
+    width: 100%;
+    height: auto;
+    min-height: var(--aspect-percent);
+    transition-property: opacity;
+    transition-duration: .2s;
+    transition-timing-function: ease;
+    overflow: hidden;
+    border-radius: var(--borderRadius);
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0
+}
+
+.c97c5c .no-image:before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to right, var(--fallbackBackground), var(--fallbackBackground)), linear-gradient(to right, var(--color-canvas), var(--color-canvas));
+    position: absolute;
+    top: 0;
+    left: 0
+}
+
+.c97c5c .no-image:after {
+    content: var(--fallbackLetter);
+    color: var(--fallbackColor);
+    font-size: 18rem;
+    font-weight: 500;
+    font-family: var(--fontSerifAlt);
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: -4rem;
+    left: -1rem
+}
+
+.pkyzfxz {
+    font-family: Graphik Web;
+    color: var(--color-textSecondary);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 2rem
+}
+
+.pkyzfxz img {
+    margin-left: .5rem;
+    max-width: 8rem
+}
+
+.colormode-dark .pkyzfxz img {
+    mix-blend-mode: exclusion;
+    filter: invert(1)
+}
+
+.colormode-sepia .pkyzfxz img {
+    mix-blend-mode: multiply
+}
+
+.o179acbt {
+    color: var(--color-textSecondary);
+    font-weight: 300;
+    text-transform: uppercase;
+    -webkit-letter-spacing: .014em;
+    -moz-letter-spacing: .014em;
+    -ms-letter-spacing: .014em;
+    letter-spacing: .014em;
+    line-height: 1.75;
+    transform: translateY(-.25rem)
+}
+
+.trxac13 {
+    font-family: Graphik Web;
+    border-radius: 4px;
+    display: inline-flex;
+    align-content: center;
+    align-items: center;
+    line-height: 24px;
+    height: 24px;
+    padding: 0 .5em;
+    position: relative;
+    white-space: nowrap;
+    font-weight: 400;
+    font-size: 16px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none
+}
+
+.trxac13 .icon {
+    margin-top: 0
+}
+
+.t9ef2pv {
+    text-transform: lowercase;
+    max-width: 100%;
+    overflow: hidden;
+    vertical-align: bottom;
+    cursor: auto
+}
+
+.t9ef2pv,
+.t9ef2pv:hover {
+    background-color: var(--color-dividerTertiary);
+    color: var(--color-textPrimary)
+}
+
+.t9ef2pv.selected {
+    background-color: var(--color-actionPrimary);
+    color: var(--color-actionPrimaryText)
+}
+
+.t9ef2pv.selected:hover {
+    color: var(--color-actionPrimaryText);
+    background-color: var(--color-actionPrimaryHover)
+}
+
+.cn6urtm,
+.t9ef2pv.action {
+    cursor: pointer
+}
+
+.cn6urtm {
+    margin-left: 8px;
+    line-height: 0;
+    height: 100%
+}
+
+.cn6urtm:hover {
+    color: var(--color-textPrimary);
+    background-color: transparent
+}
+
+.cn6urtm.selected:hover {
+    color: var(--color-actionPrimaryText)
+}
+
+.c18o9ext {
+    --card-column-span: span 12;
+    --card-row-span: span 1;
+    --media-column-span: span 4;
+    --content-column-span: span 8;
+    padding: 0;
+    font-family: var(--fontSansSerif);
+    font-weight: 400;
+    z-index: 0;
+    grid-column: var(--card-column-span);
+    grid-row: var(--card-row-span)
+}
+
+.c18o9ext,
+.c18o9ext .cardWrap {
+    width: 100%;
+    height: 100%;
+    position: relative
+}
+
+.c18o9ext .cardWrap {
+    -webkit-text-decoration: none;
+    text-decoration: none;
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    grid-column-gap: var(--size150);
+    padding-bottom: 0
+}
+
+.c18o9ext .cardWrap:hover .view-original {
+    opacity: 1;
+    transition: opacity .3s ease-in-out
+}
+
+.c18o9ext .cardWrap a {
+    -webkit-text-decoration: none;
+    text-decoration: none
+}
+
+.c18o9ext .cardWrap a:focus {
+    outline: none
+}
+
+.c18o9ext .cardWrap a:focus,
+.c18o9ext .cardWrap a:hover {
+    -webkit-text-decoration: underline;
+    text-decoration: underline
+}
+
+.c18o9ext .cardWrap a:hover {
+    color: var(--color-textPrimary)
+}
+
+@media (hover:hover) and (pointer:fine) {
+    .c18o9ext .cardWrap:hover .media img {
+        filter: brightness(.95) saturate(.8);
+        transition: filter .3s ease-in-out
+    }
+}
+
+.c18o9ext .media {
+    position: relative;
+    grid-column: var(--media-column-span)
+}
+
+.c18o9ext .media .topic-name {
+    background: rgba(26, 26, 26, .8);
+    font-size: .875rem;
+    font-weight: 400;
+    line-height: 1.25rem;
+    border-radius: 8px;
+    bottom: 2rem;
+    left: 1rem;
+    text-transform: capitalize
+}
+
+.c18o9ext .media .topic-name,
+.c18o9ext .view-original {
+    color: var(--color-white100);
+    position: absolute;
+    padding: .25rem .825rem;
+    z-index: 10
+}
+
+.c18o9ext .view-original {
+    opacity: 0;
+    transition: opacity .3s ease-in-out;
+    background: rgba(26, 26, 26, .7);
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    align-content: center;
+    border-radius: 4px
+}
+
+@media (max-width:839px) {
+    .c18o9ext .view-original {
+        display: none
+    }
+}
+
+.c18o9ext .view-original .view-original-text+.icon {
+    margin-left: .25rem;
+    margin-top: 0
+}
+
+.c18o9ext .content {
+    width: 100%;
+    grid-column: var(--content-column-span)
+}
+
+.c18o9ext .title {
+    font-family: var(--fontSansSerif);
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.286;
+    padding: 0;
+    margin: 0;
+    max-height: 3.858em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical
+}
+
+.c18o9ext .title.flow {
+    max-height: none;
+    display: block
+}
+
+.c18o9ext .title.open-external a {
+    margin-right: 0
+}
+
+@media (max-width:839px) {
+    .c18o9ext .title.open-external a {
+        margin-right: .5rem
+    }
+}
+
+.c18o9ext .title.open-external .mobile-view-original {
+    display: none
+}
+
+@media (max-width:839px) {
+    .c18o9ext .title.open-external .mobile-view-original {
+        display: inline-block
+    }
+}
+
+.c18o9ext .details {
+    font-style: normal;
+    padding: var(--size050) 0;
+    font-size: var(--fontSize085);
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    align-content: center;
+    color: var(--color-textSecondary)
+}
+
+.c18o9ext .authors {
+    padding-right: .625rem;
+    display: inline-block
+}
+
+.c18o9ext .authors span:after {
+    content: ",";
+    display: inline-block;
+    padding: 0 .5rem 0 0
+}
+
+.c18o9ext .authors span:last-of-type:after {
+    content: "";
+    display: none;
+    padding: 0
+}
+
+.c18o9ext .authors+.publisher:before {
+    content: "·";
+    display: inline-block;
+    padding: 0 .625rem 0 0
+}
+
+.c18o9ext .publisher {
+    font-style: normal;
+    display: inline-block;
+    max-width: 70%;
+    overflow-x: hidden;
+    padding: 0 .25rem 0 0;
+    text-overflow: ellipsis
+}
+
+.c18o9ext .publisher,
+.c18o9ext .publisher:hover {
+    color: var(--color-textSecondary);
+}
+
+.c18o9ext .readtime {
+    white-space: nowrap
+}
+
+.c18o9ext .syndicated {
+    display: inline-block;
+    padding-left: var(--spacing050)
+}
+
+.c18o9ext .excerpt p {
+    font-size: var(--fontSize100);
+    margin: 0 0 1rem
+}
+
+.c18o9ext .excerpt p strong {
+    font-weight: 500
+}
+
+.c18o9ext.clamped .excerpt p {
+    max-height: calc(3 * 1.5em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical
+}
+
+.c18o9ext .markdown a {
+    -webkit-text-decoration: underline;
+    text-decoration: underline
+}
+
+.c18o9ext .markdown a:hover {
+    color: var(--color-textLinkHover);
+}
+
+.c18o9ext .footer {
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    display: grid;
+    grid-template-columns: repeat(12, 1fr)
+}
+
+.c18o9ext.noExcerpt .excerpt {
+    display: none
+}
+
+.c18o9ext.bulkEdit {
+    cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none
+}
+
+.c18o9ext.bulkEdit .actions,
+.c18o9ext.bulkEdit a {
+    pointer-events: none
+}
+
+.c18o9ext .selectedBack {
+    position: absolute;
+    box-sizing: content-box;
+    border-radius: var(--borderRadius);
+    width: 100%;
+    height: 100%;
+    transform: translate(-.625rem, -.75rem);
+    display: none;
+    padding: 0 .625rem .75rem;
+    z-index: -1
+}
+
+.c18o9ext.list .selectedBack {
+    padding: .125em 1.1em
+}
+
+.c18o9ext.selected .selectedBack,
+.c18o9ext.selected:focus-within .selectedBack {
+    background-color: var(--color-navCurrentTab);
+    display: block
+}
+
+.c18o9ext.block,
+.c18o9ext.grid {
+    --card-column-span: span 4
+}
+
+.c18o9ext.block .cardWrap,
+.c18o9ext.grid .cardWrap {
+    display: block;
+    padding-bottom: 2.5rem
+}
+
+.c18o9ext.block.hiddenActions .actions a,
+.c18o9ext.block.hiddenActions .actions button,
+.c18o9ext.grid.hiddenActions .actions a,
+.c18o9ext.grid.hiddenActions .actions button {
+    display: none
+}
+
+.c18o9ext.block.hiddenActions .actions a.active,
+.c18o9ext.block.hiddenActions .actions button.active,
+.c18o9ext.grid.hiddenActions .actions a.active,
+.c18o9ext.grid.hiddenActions .actions button.active {
+    display: flex
+}
+
+.c18o9ext.block.hiddenActions:focus-within .actions a,
+.c18o9ext.block.hiddenActions:focus-within .actions button,
+.c18o9ext.block.hiddenActions:hover .actions a,
+.c18o9ext.block.hiddenActions:hover .actions button,
+.c18o9ext.grid.hiddenActions:focus-within .actions a,
+.c18o9ext.grid.hiddenActions:focus-within .actions button,
+.c18o9ext.grid.hiddenActions:hover .actions a,
+.c18o9ext.grid.hiddenActions:hover .actions button {
+    display: flex;
+}
+
+.c18o9ext.block .footer .actions,
+.c18o9ext.grid .footer .actions {
+    grid-column: span 12
+}
+
+@media (max-width:719px) {
+
+    .c18o9ext.block,
+    .c18o9ext.grid {
+        --card-column-span: span 12
+    }
+
+    .c18o9ext.block.hiddenActions .actions,
+    .c18o9ext.grid.hiddenActions .actions {
+        display: flex;
+        justify-content: flex-end;
+        padding: 0 0 1rem
+    }
+
+    .c18o9ext.block.hiddenActions .actions a,
+    .c18o9ext.block.hiddenActions .actions button,
+    .c18o9ext.grid.hiddenActions .actions a,
+    .c18o9ext.grid.hiddenActions .actions button {
+        display: flex
+    }
+
+    .c18o9ext.block:last-of-type,
+    .c18o9ext.grid:last-of-type {
+        border-bottom: none
+    }
+
+    .c18o9ext.block .cardWrap,
+    .c18o9ext.grid .cardWrap {
+        display: grid;
+        padding-bottom: 1.85rem
+    }
+
+    .c18o9ext.block .footer .actions,
+    .c18o9ext.grid .footer .actions {
+        grid-column: 5/span 8;
+        padding-bottom: .5rem
+    }
+
+    .c18o9ext.block .footer .actions .item-actions,
+    .c18o9ext.grid .footer .actions .item-actions {
+        transform: none
+    }
+}
+
+.c18o9ext.display,
+.c18o9ext.wide {
+    --card-column-span: span 8
+}
+
+.c18o9ext.display .content,
+.c18o9ext.wide .content {
+    padding-bottom: var(--size250)
+}
+
+.c18o9ext.display .title,
+.c18o9ext.wide .title {
+    font-size: var(--fontSize150);
+    line-height: 1.286;
+    max-height: 3.8em
+}
+
+.c18o9ext.display .title.flow,
+.c18o9ext.wide .title.flow {
+    max-height: none
+}
+
+.c18o9ext.display .footer,
+.c18o9ext.wide .footer {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    grid-column-gap: var(--size150)
+}
+
+.c18o9ext.display .footer .actions,
+.c18o9ext.wide .footer .actions {
+    grid-column: 5/-1
+}
+
+.c18o9ext.display.noMedia .content,
+.c18o9ext.wide.noMedia .content {
+    grid-column: span 8
+}
+
+@media (max-width:959px) {
+
+    .c18o9ext.display,
+    .c18o9ext.wide {
+        --card-column-span: span 10
+    }
+}
+
+@media (max-width:599px) {
+
+    .c18o9ext.display,
+    .c18o9ext.wide {
+        --card-column-span: span 12
+    }
+
+    .c18o9ext.display .title,
+    .c18o9ext.wide .title {
+        font-size: 1rem;
+        line-height: 1.25
+    }
+}
+
+@media (max-width:479px) {
+
+    .c18o9ext.display .excerpt,
+    .c18o9ext.wide .excerpt {
+        display: none
+    }
+}
+
+.c18o9ext.display {
+    --card-column-span: span 4
+}
+
+.c18o9ext.display .title {
+    font-size: .85rem;
+    line-height: 1.286;
+    max-height: 2.6em
+}
+
+.c18o9ext.display .title.flow {
+    max-height: none
+}
+
+.c18o9ext.display .details {
+    padding: 0 0 var(--size050);
+    font-size: .725rem
+}
+
+.c18o9ext.display .actions {
+    padding: 0 0 .725rem;
+    transform: translateX(-.25rem)
+}
+
+.c18o9ext.display .actions .actionCopy {
+    font-size: .85rem
+}
+
+@media (max-width:1023px) {
+    .c18o9ext.display {
+        --media-column-span: span 12;
+        --content-column-span: span 12
+    }
+
+    .c18o9ext.display .cardWrap {
+        grid-column-gap: 0
+    }
+
+    .c18o9ext.display .footer .actions {
+        grid-column: span 12
+    }
+}
+
+@media (max-width:719px) {
+    .c18o9ext.display {
+        --card-column-span: span 12;
+        --media-column-span: span 4;
+        --content-column-span: span 8
+    }
+
+    .c18o9ext.display .cardWrap {
+        grid-column-gap: 1rem;
+        padding-bottom: .25rem
+    }
+
+    .c18o9ext.display .title {
+        font-size: 1rem;
+        line-height: 1.25
+    }
+
+    .c18o9ext.display .details {
+        font-style: normal;
+        padding: var(--size050) 0;
+        font-size: var(--fontSize085);
+        line-height: 1.5;
+        display: block;
+        color: var(--color-textSecondary)
+    }
+
+    .c18o9ext.display.hiddenActions .actions {
+        display: flex;
+        justify-content: flex-end;
+        padding: 0 0 1rem
+    }
+
+    .c18o9ext.display.hiddenActions .actions a,
+    .c18o9ext.display.hiddenActions .actions button {
+        display: flex
+    }
+
+    .c18o9ext.display:last-of-type {
+        border-bottom: none
+    }
+
+    .c18o9ext.display .footer .actions {
+        grid-column: 5/span 8;
+        padding-bottom: 1rem
+    }
+
+    .c18o9ext.display .footer .actions .item-actions {
+        transform: none
+    }
+}
+
+.c18o9ext.list {
+    padding: var(--size100) 0;
+    border-bottom: 1px solid var(--color-dividerTertiary)
+}
+
+.c18o9ext.list .media {
+    grid-column: span 1;
+    padding-bottom: 0;
+    margin-bottom: 0
+}
+
+.c18o9ext.list .view-original .icon {
+    margin-left: 0
+}
+
+.c18o9ext.list .view-original-text {
+    display: none
+}
+
+.c18o9ext.list .content {
+    grid-column: span 11
+}
+
+.c18o9ext.list .title {
+    width: 70%;
+    white-space: nowrap
+}
+
+.c18o9ext.list .details {
+    font-size: var(--fontSize085);
+    line-height: 1.5;
+    padding: 0
+}
+
+.c18o9ext.list .excerpt {
+    display: none
+}
+
+.c18o9ext.list .footer {
+    width: auto;
+    position: absolute;
+    display: block;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%)
+}
+
+.c18o9ext.list .footer .actions {
+    padding: 0
+}
+
+.c18o9ext.list .selectedBack {
+    padding: .125em .625em;
+    transform: translate(-.625rem, -1.1rem)
+}
+
+@media (max-width:959px) {
+    .c18o9ext.list .media {
+        display: none
+    }
+
+    .c18o9ext.list .content {
+        grid-column: span 12
+    }
+}
+
+@media (max-width:719px) {
+    .c18o9ext.list .cardWrap {
+        height: auto
+    }
+
+    .c18o9ext.list .title {
+        width: 100%
+    }
+
+    .c18o9ext.list .footer {
+        width: auto;
+        position: relative;
+        top: auto;
+        right: auto;
+        transform: translateY(0)
+    }
+
+    .c18o9ext.list .actions {
+        grid-column: span 12;
+        padding-top: .5rem;
+        justify-content: flex-end
+    }
+}
+
+.c18o9ext.detail {
+    grid-column: span 12;
+    height: 160px;
+    padding: 1em 0;
+    border-bottom: 1px solid var(--color-dividerTertiary)
+}
+
+.c18o9ext.detail:last-of-type {
+    border-bottom: none
+}
+
+.c18o9ext.detail .media {
+    grid-column: span 2
+}
+
+.c18o9ext.detail .view-original .icon {
+    margin-left: 0
+}
+
+.c18o9ext.detail .view-original-text {
+    display: none
+}
+
+.c18o9ext.detail .content {
+    grid-column: span 10;
+    position: relative
+}
+
+.c18o9ext.detail .title {
+    width: 70%;
+    white-space: nowrap
+}
+
+.c18o9ext.detail.full .title {
+    width: 100%
+}
+
+.c18o9ext.detail .details {
+    padding: var(--size025) 0
+}
+
+.c18o9ext.detail .excerpt {
+    font-size: var(--fontSize085);
+    max-height: 3.2em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block
+}
+
+.c18o9ext.detail .footer {
+    align-items: center;
+    align-content: center;
+    padding-top: .5rem;
+    bottom: .5rem;
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    grid-column-gap: var(--size150)
+}
+
+.c18o9ext.detail .selectedBack {
+    height: calc(100% - .5rem);
+    transform: translate(-.5rem, -1rem);
+    padding: .25rem .5rem
+}
+
+.c18o9ext.detail .tags {
+    grid-column: 3/span 7;
+    overflow: hidden;
+    white-space: nowrap;
+    padding: 4px 0
+}
+
+.c18o9ext.detail .tags a {
+    font-size: 14px;
+    margin-right: .5em;
+    cursor: pointer;
+    -webkit-text-decoration: none;
+    text-decoration: none
+}
+
+.c18o9ext.detail .actions {
+    grid-column: 10/span 3;
+    padding: 0;
+    justify-content: flex-end
+}
+
+@media (max-width:1023px) {
+    .c18o9ext.detail .tags {
+        grid-column: 1/span 9
+    }
+
+    .c18o9ext.detail .actions {
+        grid-column: 10/span 3
+    }
+}
+
+@media (max-width:959px) {
+    .c18o9ext.detail .tags {
+        grid-column: 1/span 8
+    }
+
+    .c18o9ext.detail .actions {
+        grid-column: 9/span 4
+    }
+}
+
+@media (max-width:839px) {
+    .c18o9ext.detail .content {
+        grid-column: span 8
+    }
+
+    .c18o9ext.detail .media {
+        grid-column: span 4
+    }
+
+    .c18o9ext.detail .tags {
+        grid-column: 1/span 8
+    }
+
+    .c18o9ext.detail .actions {
+        grid-column: 9/span 3
+    }
+}
+
+@media (max-width:719px) {
+    .c18o9ext.detail {
+        height: 185px
+    }
+
+    .c18o9ext.detail .tags {
+        grid-column: span 12
+    }
+
+    .c18o9ext.detail .actions {
+        grid-column: span 12;
+        padding-top: .5rem;
+        justify-content: flex-end
+    }
+}
+
+@media (max-width:599px) {
+    .c18o9ext.detail .content {
+        grid-column: span 12
+    }
+
+    .c18o9ext.detail .media {
+        display: none
+    }
+}
+
+.c18o9ext.flex .title {
+    font-size: 1rem
+}
+
+@media (max-width:599px) {
+    .c18o9ext.flex .title {
+        font-size: 1rem
+    }
+}
+
+.c18o9ext.flex+.flex {
+    grid-column: span 6
+}
+
+@media (max-width:1279px) {
+    .c18o9ext.flex .view-original-text {
+        display: none
+    }
+}
+
+@media (max-width:959px) {
+    .c18o9ext.flex {
+        --media-column-span: span 12;
+        --content-column-span: span 12
+    }
+
+    .c18o9ext.flex .view-original-text {
+        display: inline
+    }
+}
+
+@media (max-width:839px) {
+    .c18o9ext.flex {
+        --media-column-span: span 4;
+        --content-column-span: span 8
+    }
+}
+
+@media (max-width:719px) {
+    .c18o9ext.flex {
+        padding-bottom: 2.5rem
+    }
+}
+
+.c18o9ext.flex:only-of-type {
+    grid-column: span 12;
+    --media-column-span: span 3;
+    --content-column-span: span 9
+}
+
+.c18o9ext.flex:only-of-type .title {
+    font-size: 1.25rem
+}
+
+.c18o9ext.flex:only-of-type .view-original-text {
+    display: inline
+}
+
+@media (max-width:959px) {
+    .c18o9ext.flex:only-of-type {
+        --media-column-span: span 4;
+        --content-column-span: span 8
+    }
+
+    .c18o9ext.flex:only-of-type .title {
+        font-size: 1rem
+    }
+}
+
+@media (max-width:719px) {
+    .c18o9ext.flex:only-of-type .excerpt {
+        display: none
+    }
+}
+
+.c18o9ext.flex:first-child:nth-last-child(n+2),
+.c18o9ext.flex:first-child:nth-last-child(n+2)~* {
+    grid-column: span 6
+}
+
+.c18o9ext.flex:first-child:nth-last-child(n+2) .view-original-text,
+.c18o9ext.flex:first-child:nth-last-child(n+2)~* .view-original-text {
+    display: none
+}
+
+@media (max-width:839px) {
+
+    .c18o9ext.flex:first-child:nth-last-child(n+2),
+    .c18o9ext.flex:first-child:nth-last-child(n+2)~* {
+        --media-column-span: span 4;
+        --content-column-span: span 8;
+        grid-column: span 12;
+        padding-bottom: 0
+    }
+
+    .c18o9ext.flex:first-child:nth-last-child(n+2) .cardWrap,
+    .c18o9ext.flex:first-child:nth-last-child(n+2)~* .cardWrap {
+        grid-column-gap: 1.5rem
+    }
+}
+
+.c18o9ext.flex:first-child:nth-last-child(n+3),
+.c18o9ext.flex:first-child:nth-last-child(n+3)~* {
+    grid-column: span 4
+}
+
+@media (max-width:1023px) {
+
+    .c18o9ext.flex:first-child:nth-last-child(n+3),
+    .c18o9ext.flex:first-child:nth-last-child(n+3)~* {
+        --media-column-span: span 12;
+        --content-column-span: span 12
+    }
+
+    .c18o9ext.flex:first-child:nth-last-child(n+3) .view-original-text,
+    .c18o9ext.flex:first-child:nth-last-child(n+3)~* .view-original-text {
+        display: inline
+    }
+}
+
+@media (max-width:959px) {
+
+    .c18o9ext.flex:first-child:nth-last-child(n+3) .cardWrap,
+    .c18o9ext.flex:first-child:nth-last-child(n+3)~* .cardWrap {
+        grid-column-gap: 0
+    }
+}
+
+@media (max-width:839px) {
+
+    .c18o9ext.flex:first-child:nth-last-child(n+3),
+    .c18o9ext.flex:first-child:nth-last-child(n+3)~* {
+        --media-column-span: span 4;
+        --content-column-span: span 8;
+        grid-column: span 12;
+        padding-bottom: 0
+    }
+
+    .c18o9ext.flex:first-child:nth-last-child(n+3) .cardWrap,
+    .c18o9ext.flex:first-child:nth-last-child(n+3)~* .cardWrap {
+        grid-column-gap: 1.5rem
+    }
+}
+
+.lockup-hero .c18o9ext {
+    --card-column-span: span 3;
+    border-bottom: 0
+}
+
+.lockup-hero .c18o9ext .title {
+    font-size: var(--fontSize125);
+    line-height: 1.263
+}
+
+.lockup-hero .c18o9ext.hero-center .title,
+.lockup-hero .c18o9ext.hero-left .title,
+.lockup-hero .c18o9ext.hero-right .title {
+    font-size: var(--fontSize200);
+    line-height: 1.212;
+    max-height: 4.848em
+}
+
+.lockup-hero .c18o9ext.hero-center .title.flow,
+.lockup-hero .c18o9ext.hero-left .title.flow,
+.lockup-hero .c18o9ext.hero-right .title.flow {
+    max-height: none
+}
+
+.lockup-hero .c18o9ext.hero-center {
+    --card-row-span: span 2;
+    --card-column-span: 4/span 6
+}
+
+.lockup-hero .c18o9ext.hero-left {
+    --card-row-span: span 2;
+    --card-column-span: 1/span 6
+}
+
+.lockup-hero .c18o9ext.hero-right {
+    --card-row-span: span 2;
+    --card-column-span: 7/span 6
+}
+
+@media (max-width:1023px) {
+
+    .lockup-hero .c18o9ext.hero-center .title,
+    .lockup-hero .c18o9ext.hero-left .title,
+    .lockup-hero .c18o9ext.hero-right .title {
+        font-size: 1.75rem;
+        line-height: 1.179
+    }
+
+    .lockup-hero .c18o9ext .details,
+    .lockup-hero .c18o9ext .excerpt {
+        font-size: .85rem;
+        line-height: 1.429
+    }
+}
+
+@media (max-width:959px) {
+
+    .lockup-hero .c18o9ext.hero-center,
+    .lockup-hero .c18o9ext.hero-left,
+    .lockup-hero .c18o9ext.hero-right {
+        --card-row-span: span 2;
+        --card-column-span: 1/span 6
+    }
+}
+
+@media (max-width:719px) {
+    .lockup-hero .c18o9ext {
+        --card-column-span: span 6
+    }
+
+    .lockup-hero .c18o9ext.hero-center,
+    .lockup-hero .c18o9ext.hero-left,
+    .lockup-hero .c18o9ext.hero-right {
+        --card-row-span: span 2;
+        --card-column-span: 1/-1
+    }
+
+    .lockup-hero .c18o9ext.hero-center .details,
+    .lockup-hero .c18o9ext.hero-left .details,
+    .lockup-hero .c18o9ext.hero-right .details {
+        padding: var(--spacing050) 0
+    }
+
+    .lockup-hero .c18o9ext.hero-center .title,
+    .lockup-hero .c18o9ext.hero-left .title,
+    .lockup-hero .c18o9ext.hero-right .title {
+        max-height: calc(1em * 5.25)
+    }
+
+    .lockup-hero .c18o9ext.hero-center .title.flow,
+    .lockup-hero .c18o9ext.hero-left .title.flow,
+    .lockup-hero .c18o9ext.hero-right .title.flow {
+        max-height: none
+    }
+}
+
+@media (max-width:599px) {
+    .lockup-hero .c18o9ext {
+        --card-column-span: span 12
+    }
+
+    .lockup-hero .c18o9ext.hero-center .title,
+    .lockup-hero .c18o9ext.hero-left .title,
+    .lockup-hero .c18o9ext.hero-right .title {
+        font-size: 1.125rem;
+        line-height: 1.286;
+        max-height: 4.725em
+    }
+
+    .lockup-hero .c18o9ext.hero-center .title.flow,
+    .lockup-hero .c18o9ext.hero-left .title.flow,
+    .lockup-hero .c18o9ext.hero-right .title.flow {
+        max-height: none
+    }
+
+    .lockup-hero .c18o9ext:nth-child(n+2) .excerpt {
+        display: none
+    }
+
+    .lockup-hero .c18o9ext:nth-child(n+2) .title {
+        font-size: 1rem;
+        line-height: 1.25
+    }
+}
+
+@media (max-width:479px) {
+
+    .lockup-hero .c18o9ext.hero-center,
+    .lockup-hero .c18o9ext.hero-left,
+    .lockup-hero .c18o9ext.hero-right {
+        --card-row-span: span 2;
+        --card-column-span: 1/-1
+    }
+
+    .lockup-hero .c18o9ext.hero-center .content,
+    .lockup-hero .c18o9ext.hero-center .media,
+    .lockup-hero .c18o9ext.hero-left .content,
+    .lockup-hero .c18o9ext.hero-left .media,
+    .lockup-hero .c18o9ext.hero-right .content,
+    .lockup-hero .c18o9ext.hero-right .media {
+        grid-column: span 12
+    }
+
+    .lockup-hero .c18o9ext.hero-center .title,
+    .lockup-hero .c18o9ext.hero-left .title,
+    .lockup-hero .c18o9ext.hero-right .title {
+        font-size: 1.25rem;
+        line-height: 1.286;
+        max-height: 4.725em
+    }
+
+    .lockup-hero .c18o9ext.hero-center .title.flow,
+    .lockup-hero .c18o9ext.hero-left .title.flow,
+    .lockup-hero .c18o9ext.hero-right .title.flow {
+        max-height: none
+    }
+
+    .lockup-hero .c18o9ext.hero-center .footer .actions,
+    .lockup-hero .c18o9ext.hero-left .footer .actions,
+    .lockup-hero .c18o9ext.hero-right .footer .actions {
+        grid-column: 1/-1
+    }
+
+    .lockup-hero .c18o9ext.hero-center .details,
+    .lockup-hero .c18o9ext.hero-left .details,
+    .lockup-hero .c18o9ext.hero-right .details {
+        padding: var(--spacing050) 0
+    }
+}
+
+@media (max-width:399px) {
+
+    .lockup-hero .c18o9ext.hero-center .title,
+    .lockup-hero .c18o9ext.hero-left .title,
+    .lockup-hero .c18o9ext.hero-right .title {
+        font-size: 1.25rem
+    }
+}
+
+.c18o9ext.discover {
+    padding: 1.5rem 0;
+    border-bottom: 1px solid var(--color-dividerTertiary)
+}
+
+.c18o9ext.discover:last-of-type {
+    border-bottom: none
+}
+
+.c18o9ext.discover .media {
+    grid-column: span 4
+}
+
+.c18o9ext.discover .content {
+    grid-column: span 8
+}
+
+.c18o9ext.discover .title {
+    padding: 0;
+    font-size: var(--fontSize150);
+    line-height: 1.286
+}
+
+.c18o9ext.discover .footer .actions {
+    grid-column: 5/span 8
+}
+
+@media (max-width:719px) {
+    .c18o9ext.collection {
+        --card-column-span: span 12
+    }
+
+    .c18o9ext.collection .content,
+    .c18o9ext.collection .media {
+        grid-column: span 12
+    }
+
+    .c18o9ext.collection .title {
+        font-size: 1.25rem;
+        line-height: 1.286;
+        max-height: 4.825em
+    }
+
+    .c18o9ext.collection .title.flow {
+        max-height: none
+    }
+
+    .c18o9ext.collection .footer .actions {
+        grid-column: 1/-1
+    }
+}
+
+.c18o9ext.homeCard .footer .card-actions .icon {
+    margin-left: -6px
+}
+
+@media (max-width:1279px) {
+    .c18o9ext.homeCard .details {
+        flex-direction: column;
+        align-content: flex-start;
+        align-items: flex-start
+    }
+
+    .c18o9ext.homeCard .authors {
+        color: var(--color-textPrimary)
+    }
+
+    .c18o9ext.homeCard .authors+.publisher:before {
+        content: "";
+        display: none;
+        padding: 0
+    }
+
+    .c18o9ext.homeCard .publisher {
+        max-width: 100%
+    }
+}
+
+@media (max-width:719px) {
+    .c18o9ext.homeCard {
+        --card-column-span: span 12;
+        padding-bottom: 2rem
+    }
+
+    .c18o9ext.homeCard .content,
+    .c18o9ext.homeCard .media {
+        grid-column: span 12
+    }
+
+    .c18o9ext.homeCard .title {
+        font-size: 1.25rem;
+        line-height: 1.286;
+        max-height: 4.825em
+    }
+
+    .c18o9ext.homeCard .title.flow {
+        max-height: none
+    }
+
+    .c18o9ext.homeCard .details {
+        flex-direction: row;
+        align-content: flex-start;
+        align-items: flex-start
+    }
+
+    .c18o9ext.homeCard .authors+.publisher:before {
+        content: "·";
+        display: inline-block;
+        padding: 0 .625rem 0 0
+    }
+
+    .c18o9ext.homeCard .publisher {
+        max-width: 70%
+    }
+
+    .c18o9ext.homeCard .footer .actions {
+        grid-column: 1/-1
+    }
+}
+
+.smallCards .c18o9ext {
+    --media-column-span: 1;
+    --content-column-span: 2/-1
+}
+
+.smallCards .c18o9ext .cardWrap {
+    display: grid;
+    height: auto;
+    padding-bottom: 0;
+    grid-column-gap: 1rem;
+    grid-template-columns: repeat(3, 1fr)
+}
+
+.smallCards .c18o9ext .media {
+    padding-bottom: 0
+}
+
+.smallCards .c18o9ext .excerpt,
+.smallCards .c18o9ext .topic-name,
+.smallCards .c18o9ext .view-original {
+    display: none
+}
+
+.smallCards .c18o9ext .details {
+    padding: .25rem 0
+}
+
+.smallCards .c18o9ext .footer {
+    position: static;
+    bottom: auto;
+    grid-template-columns: repeat(3, 1fr);
+    grid-column-gap: 1rem
+}
+
+.smallCards .c18o9ext .footer .actions {
+    padding-top: 0;
+    grid-column: 2/-1
+}
+
+
+.fa-lg {
+    vertical-align: -0.6em;
+}

--- a/static/css/mylist/header.css
+++ b/static/css/mylist/header.css
@@ -2035,5 +2035,3 @@ a:hover .b1bq2cra {
     align-items: center;
     flex: 1 1
 }
-/*# sourceMappingURL=5df907bfb44ca4e3.css.map*/
-

--- a/static/css/mylist/nav.css
+++ b/static/css/mylist/nav.css
@@ -120,11 +120,6 @@ a:hover {
     text-decoration:underline
 }
 
-a:not([href]):not([tabindex]), a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-    color: inherit;
-    text-decoration:none
-}
-
 a:not([href]):not([tabindex]):focus {
     outline:0
 }
@@ -209,9 +204,9 @@ select {
     -webkit-appearance:button
 }
 
-[type=button]:not(:disabled), [type=reset]:not(:disabled), [type=submit]:not(:disabled), button:not(:disabled) {
+/* [type=button]:not(:disabled), [type=reset]:not(:disabled), [type=submit]:not(:disabled), button:not(:disabled) {
     cursor:pointer
-}
+} */
 
 [type=button]::-moz-focus-inner, [type=reset]::-moz-focus-inner, [type=submit]::-moz-focus-inner, button::-moz-focus-inner {
     border-style: none;
@@ -1800,5 +1795,4 @@ body.modal-open {
     color: var(--color-textSecondary);
     word-break: break-all
 }
-/*# sourceMappingURL=dd049667434a30d2.css.map*/
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,0 +1,135 @@
+
+
+function createNode(tag) {
+    /* tag를 생성하는 함수 */
+
+    return document.createElement(tag);
+}
+
+function appendTag(parent, element) {
+    /* parent tag에 child tag를 추가하는 함수 */
+
+    return parent.appendChild(element);
+}
+
+function makeFavoriteInToolBar(parentNode) {
+    /* 하단 툴바의 즐겨찾기 버튼 Dom을 만드는 함수 */
+
+    const favoriteButtonContainer = createNode('span')
+    appendTag(parentNode, favoriteButtonContainer)
+
+    const favoriteButton = createNode('button')
+    favoriteButton.className = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    favoriteButton.setAttribute('data-tooltip', '즐겨찾기')
+    appendTag(favoriteButtonContainer, favoriteButton)
+
+    const favoriteIconContainer = createNode('span')
+    favoriteIconContainer.className = 'i1qqph0t icon'
+    appendTag(favoriteButton, favoriteIconContainer)
+
+    const favoriteIcon = createNode('i')
+    favoriteIcon.className = 'fa-regular fa-star fa-lg'
+    appendTag(favoriteIconContainer, favoriteIcon)
+
+}
+
+function makeCategoryInToolBar(parentNode) {
+    /* 하단 툴바의 category button Dom을 만드는 함수 */
+
+    const categoryButtonContainer = createNode('span')
+    appendTag(parentNode, categoryButtonContainer)
+
+    const categoryButton = createNode('button')
+    categoryButton.className = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    categoryButton.setAttribute('data-tooltip', '카테고리')
+    appendTag(categoryButtonContainer, categoryButton)
+
+    const categoryIconContainer = createNode('span')
+    categoryIconContainer.className = 'i1qqph0t icon'
+    appendTag(categoryButton, categoryIconContainer)
+
+    const categoryIcon = createNode('i')
+    categoryIcon.className = 'fa fa-regular fa-folder-open fa-lg'
+    appendTag(categoryIconContainer, categoryIcon)
+
+}
+
+
+function makeTagInToolBar(itemActions) {
+    /* 하단 툴바의 tag button Dom을 만드는 함수 */
+
+    const tagButtonContainer = createNode('span')
+    appendTag(itemActions, tagButtonContainer)
+
+    const tagButton = createNode('button')
+    tagButton.className = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    tagButton.setAttribute('data-tooltip', '태그')
+    appendTag(tagButtonContainer, tagButton)
+
+    const tagIconContainer = createNode('span')
+    tagIconContainer.className = 'i1qqph0t icon'
+    appendTag(tagButton, tagIconContainer)
+
+    
+    const tagIcon = createNode('i')
+    tagIcon.className = 'fa-regular fa-hashtag fa-lg'
+    appendTag(tagIconContainer, tagIcon)
+
+}
+
+function makeDeleteInToolBar(parentNode) {
+     /* 하단 툴바의 delete button Dom을 만드는 함수 */
+
+    const deleteButtonContainer = createNode('span')
+    appendTag(parentNode, deleteButtonContainer)
+
+    const deleteButton = createNode('button')
+    deleteButton.className = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    deleteButton.setAttribute('data-tooltip', '삭제')
+    appendTag(deleteButtonContainer, deleteButton)
+
+    const deleteIconContainer = createNode('span')
+    deleteIconContainer.className = 'i1qqph0t icon'
+    appendTag(deleteButton, deleteIconContainer)
+
+
+    const deleteIcon = createNode('i')
+    deleteIcon.className = 'fa fa-regular fa-trash fa-lg'
+    appendTag(deleteIconContainer, deleteIcon)
+
+}
+
+function makeBottomToolbar(parentNode) {
+    /*각 항목마다 하단 툴바를 만드는 함수*/
+
+     // bottom toolbar container - footer
+     const footer = createNode('footer')
+     footer.className = 'footer'
+     appendTag(parentNode, footer)
+ 
+     const itemActionsContainer = createNode('div')
+     itemActionsContainer.className = 'i18uycg6 actions'
+     appendTag(footer, itemActionsContainer)
+ 
+     const itemActions = createNode('div')
+     itemActions.className = 'item-actions'
+     appendTag(itemActionsContainer, itemActions)
+ 
+     // bottom toolbar - favorite
+     makeFavoriteInToolBar(itemActions)
+    
+     // bottom toolbar - category
+     makeCategoryInToolBar(itemActions)
+ 
+     // bottom toolbar - tag
+     makeTagInToolBar(itemActions)
+ 
+     // bottom toolbar - delete
+     makeDeleteInToolBar(itemActions)
+}
+
+export {
+    createNode, 
+    appendTag, 
+    makeBottomToolbar
+};

--- a/static/js/get-item-list.js
+++ b/static/js/get-item-list.js
@@ -1,0 +1,78 @@
+import {createNode, appendTag, makeBottomToolbar} from './common.js';
+
+const root = document.getElementById("root")
+
+function renderItem(post) {
+    /* 각 item의 tag를 rendering 하는 함수 */
+
+    const article = createNode('article')
+    article.className = 'c18o9ext grid hiddenActions noExcerpt'
+    appendTag(root, article)
+
+    const item = createNode('div')
+    item.className = 'cardWrap'
+    appendTag(article, item)
+
+    const imgContainer = createNode('div')
+    imgContainer.className = 'c97c5c media'
+    appendTag(item, imgContainer)
+
+    const itemLink = createNode('a')
+    itemLink.href = post.thumbnail_url
+    appendTag(imgContainer, itemLink)
+
+    const img = createNode('img')
+    img.src = post.thumbnail_url
+    img.style = '--fallbackBackground:#1CB0A880; --fallbackColor:#1CB0A8; --fallbackLetter:&quot;T&quot;;">'
+    appendTag(itemLink, img)
+
+    const content = createNode('div')
+    content.className = 'content'
+    appendTag(item, content)
+
+    const titleContainer = createNode('h2')
+    titleContainer.className = 'title'
+    appendTag(content, titleContainer)
+
+    const title = createNode('a')
+    title.innerText = post.title
+    appendTag(titleContainer, title)
+
+    const details = createNode('cite')
+    details.className = 'details'
+    appendTag(content, details)
+
+    const publisher = createNode('a')
+    publisher.className = 'publisher'
+    publisher.href = 'https://www.theatlantic.com/technology/archive/2022/10/phone-call-greeting-smartphone-technological-error/671910/?utm_source=pocket_saves'
+    publisher.innerText = 'The Atlantic'
+    appendTag(details, publisher)
+
+    // 각 항목(item)의 하단 툴바
+    makeBottomToolbar(article)
+   
+}
+
+function mapPosts(data) {
+    /* 각 데이터를 renderPost에 전달하여 rendering하는 함수 */
+
+    return data.map(item => {
+        renderItem(item);
+    })
+}
+
+
+function getItemList() {
+    /* mylist에 등록된 모든 항목들을 조회하여 함수 */
+    
+    fetch(`/api/list/`)
+    .then(response => response.json())
+    .then(data => {
+        mapPosts(data)
+    })
+    .catch(err => {
+        console.log(err);
+    })
+}
+
+getItemList()

--- a/templates/mylist/base.html
+++ b/templates/mylist/base.html
@@ -1,134 +1,166 @@
 {% load static %}
 <!DOCTYPE html>
 <html lang="ko" class="colormode-light">
+
 <head>
     <meta charset="utf-8">
+    <script type="module" src="{% static 'js/get-item-list.js' %}"></script>
+    <script src="https://kit.fontawesome.com/c7083b595c.js" crossorigin="anonymous"></script>
     
-    <link rel="stylesheet" href="{% static '/css/mylist.css' %}">  
-    <link rel="stylesheet" href="{% static '/css/mylist_header.css' %}">   
-    <link rel="stylesheet" href="{% static '/css/mylist_nav.css' %}">   
-         
+    <link rel="stylesheet" href="{% static '/css/mylist/base.css' %}">
+    <link rel="stylesheet" href="{% static '/css/mylist/header.css' %}">
+    <link rel="stylesheet" href="{% static '/css/mylist/nav.css' %}">    
+    <link rel="stylesheet" href="{% static '/css/mylist/body.css' %}">
+    <link rel="shortcut icon" href="{% static 'images/common/favicon.ico' %}">
+
     <title>Devket</title>
 </head>
+
 
 <body>
     <div id="__next" data-reactroot="">
 
-      <!-- HEADER -->
-    {% include 'mylist/header.html' %}
+        <!-- HEADER -->
+        {% include 'mylist/header.html' %}
 
         <div class="fzr3ha2">
             <div class="p16bck5y ">
                 <div class="m1jnn1pl">
                     <div class="s3icf2j side-nav" data-cy="side-nav">
                         <nav role="navigation">
-                            <button class="sv813dg  " data-cy="side-nav-home">
+                            <button class="sv813dg" data-cy="side-nav-home">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M10.671 1.442a2.004 2.004 0 0 1 2.658 0l8 7.09c.427.378.671.92.671 1.49v9.922a1.997 1.997 0 0 1-2 1.994h-3c-1.105 0-2-.893-2-1.994v-4.985c0-.275-.175-1.072-.689-1.789-.48-.67-1.201-1.203-2.311-1.203-1.11 0-1.831.533-2.311 1.203C9.175 13.887 9 14.684 9 14.96v4.986a1.996 1.996 0 0 1-2 1.993H4c-1.105 0-2-.893-2-1.994v-9.922c0-.57.244-1.112.671-1.49l8-7.09ZM12 2.932l-8 7.09v9.922h3v-4.985c0-.723.325-1.92 1.061-2.948.77-1.074 2.049-2.038 3.939-2.038 1.89 0 3.169.963 3.939 2.038.736 1.028 1.061 2.225 1.061 2.948v4.985h3v-9.922l-8-7.09ZM7 19.944Zm.002 0H7h.002Zm0 0Z">
-
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M10.671 1.442a2.004 2.004 0 0 1 2.658 0l8 7.09c.427.378.671.92.671 1.49v9.922a1.997 1.997 0 0 1-2 1.994h-3c-1.105 0-2-.893-2-1.994v-4.985c0-.275-.175-1.072-.689-1.789-.48-.67-1.201-1.203-2.311-1.203-1.11 0-1.831.533-2.311 1.203C9.175 13.887 9 14.684 9 14.96v4.986a1.996 1.996 0 0 1-2 1.993H4c-1.105 0-2-.893-2-1.994v-9.922c0-.57.244-1.112.671-1.49l8-7.09ZM12 2.932l-8 7.09v9.922h3v-4.985c0-.723.325-1.92 1.061-2.948.77-1.074 2.049-2.038 3.939-2.038 1.89 0 3.169.963 3.939 2.038.736 1.028 1.061 2.225 1.061 2.948v4.985h3v-9.922l-8-7.09ZM7 19.944Zm.002 0H7h.002Zm0 0Z">
                                         </path>
                                     </svg>
                                 </span> 홈
                             </button>
-                            <button class="sv813dg active " data-cy="side-nav-mylist">
+                            <button class="sv813dg" data-cy="side-nav-mylist">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path d="M5 5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM5 12a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM5 19a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M7 5a1 1 0 0 1 1-1h13a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 12a1 1 0 0 1 1-1h13a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 19a1 1 0 0 1 1-1h13a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path
+                                            d="M5 5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM5 12a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM5 19a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z">
+                                        </path>
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M7 5a1 1 0 0 1 1-1h13a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 12a1 1 0 0 1 1-1h13a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 19a1 1 0 0 1 1-1h13a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1Z">
 
                                         </path>
                                     </svg>
                                 </span> 내 목록
                                 <span class="b19radgi">
                                     <span class="i1qqph0t icon">
-                                        <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                            <path d="M18.765 22.848a2 2 0 0 1-2.18-.434L12 17.828l-4.586 4.586A2 2 0 0 1 4 21V6a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v15a2 2 0 0 1-1.235 1.848Z">
+                                        <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                            aria-hidden="true">
+                                            <path
+                                                d="M18.765 22.848a2 2 0 0 1-2.18-.434L12 17.828l-4.586 4.586A2 2 0 0 1 4 21V6a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v15a2 2 0 0 1-1.235 1.848Z">
 
                                             </path>
                                         </svg>
                                     </span>
                                 </span>
                             </button>
-                            <button class="sv813dg  " data-cy="side-nav-discover">
+                            <button class="sv813dg" data-cy="side-nav-discover">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M7.422 6.122a1 1 0 0 0-1.3 1.3l2.828 7.07a1 1 0 0 0 .557.558l7.071 2.828a1 1 0 0 0 1.3-1.3l-2.828-7.07a1 1 0 0 0-.557-.558L7.422 6.122Zm3.226 7.23 4.507 1.803-1.803-4.507-2.704 2.704Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M7.422 6.122a1 1 0 0 0-1.3 1.3l2.828 7.07a1 1 0 0 0 .557.558l7.071 2.828a1 1 0 0 0 1.3-1.3l-2.828-7.07a1 1 0 0 0-.557-.558L7.422 6.122Zm3.226 7.23 4.507 1.803-1.803-4.507-2.704 2.704Z">
 
                                         </path>
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 2c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Z">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 2c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Z">
 
                                         </path>
                                     </svg>
                                 </span> 검색
                             </button>
-                            
+
                             <div class="s1jxyudr">필터
 
                             </div>
-                            <button class="sv813dg  " data-cy="side-nav-archive">
+                            <button class="sv813dg" data-cy="side-nav-archive">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M1 4a2 2 0 0 1 2-2h18a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4Zm2 0v2h18V4H3Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M1 4a2 2 0 0 1 2-2h18a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4Zm2 0v2h18V4H3Z">
 
                                         </path>
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V8Zm2 10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8H5v10Z">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V8Zm2 10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8H5v10Z">
 
                                         </path>
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M15.707 11.293a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 1 1 1.414-1.414L11 14.586l3.293-3.293a1 1 0 0 1 1.414 0Z">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M15.707 11.293a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 1 1 1.414-1.414L11 14.586l3.293-3.293a1 1 0 0 1 1.414 0Z">
 
                                         </path>
                                     </svg>
                                 </span> 카테고리
                             </button>
-                            <button class="sv813dg  " data-cy="side-nav-favorites">
+                            <button class="sv813dg" data-cy="side-nav-favorites">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 1a1 1 0 0 1 .897.557l2.706 5.484 6.051.88a1 1 0 0 1 .555 1.705l-4.38 4.268 1.034 6.027a1 1 0 0 1-1.45 1.054L12 18.13l-5.413 2.845a1 1 0 0 1-1.45-1.054l1.033-6.027-4.379-4.268a1 1 0 0 1 .555-1.706l6.051-.88 2.706-5.483A1 1 0 0 1 12 1Zm0 3.26L9.958 8.397a1 1 0 0 1-.753.548l-4.567.663 3.305 3.221a1 1 0 0 1 .287.885l-.78 4.548 4.085-2.147a1 1 0 0 1 .93 0l4.085 2.147-.78-4.548a1 1 0 0 1 .287-.885l3.305-3.22-4.567-.664a1 1 0 0 1-.753-.548L12 4.26Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M12 1a1 1 0 0 1 .897.557l2.706 5.484 6.051.88a1 1 0 0 1 .555 1.705l-4.38 4.268 1.034 6.027a1 1 0 0 1-1.45 1.054L12 18.13l-5.413 2.845a1 1 0 0 1-1.45-1.054l1.033-6.027-4.379-4.268a1 1 0 0 1 .555-1.706l6.051-.88 2.706-5.483A1 1 0 0 1 12 1Zm0 3.26L9.958 8.397a1 1 0 0 1-.753.548l-4.567.663 3.305 3.221a1 1 0 0 1 .287.885l-.78 4.548 4.085-2.147a1 1 0 0 1 .93 0l4.085 2.147-.78-4.548a1 1 0 0 1 .287-.885l3.305-3.22-4.567-.664a1 1 0 0 1-.753-.548L12 4.26Z">
 
                                         </path>
                                     </svg>
                                 </span> 즐겨찾기
                             </button>
-                            <button class="sv813dg  " data-cy="side-nav-highlights">
+                            <button class="sv813dg" data-cy="side-nav-highlights">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M5.512 8.546a3 3 0 0 0-.51 4.195l-.724.723a3.001 3.001 0 0 0-.586 3.415L1.18 19.391a1 1 0 0 0 .39 1.656l4.243 1.414a1 1 0 0 0 1.023-.241l1.098-1.098a3.001 3.001 0 0 0 3.415-.586l.746-.746a3.001 3.001 0 0 0 4.133-.77l6.406-9.15a3 3 0 0 0-.337-3.842l-4.112-4.112a3 3 0 0 0-3.98-.233L5.512 8.546Zm9.932-5.294-8.693 6.863a1 1 0 0 0-.087 1.492l6.4 6.4a1 1 0 0 0 1.526-.134l6.405-9.15a1 1 0 0 0-.112-1.28L16.771 3.33a1 1 0 0 0-1.327-.078ZM6.4 14.172l-.707.707a1 1 0 0 0 0 1.414l2.829 2.828a1 1 0 0 0 1.414 0l.707-.707L6.4 14.172Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M5.512 8.546a3 3 0 0 0-.51 4.195l-.724.723a3.001 3.001 0 0 0-.586 3.415L1.18 19.391a1 1 0 0 0 .39 1.656l4.243 1.414a1 1 0 0 0 1.023-.241l1.098-1.098a3.001 3.001 0 0 0 3.415-.586l.746-.746a3.001 3.001 0 0 0 4.133-.77l6.406-9.15a3 3 0 0 0-.337-3.842l-4.112-4.112a3 3 0 0 0-3.98-.233L5.512 8.546Zm9.932-5.294-8.693 6.863a1 1 0 0 0-.087 1.492l6.4 6.4a1 1 0 0 0 1.526-.134l6.405-9.15a1 1 0 0 0-.112-1.28L16.771 3.33a1 1 0 0 0-1.327-.078ZM6.4 14.172l-.707.707a1 1 0 0 0 0 1.414l2.829 2.828a1 1 0 0 0 1.414 0l.707-.707L6.4 14.172Z">
 
                                         </path>
                                     </svg>
                                 </span> 하이라이트
                             </button>
-                            <button class="sv813dg  " data-cy="side-nav-articles">
+                            <button class="sv813dg" data-cy="side-nav-articles">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M17 4H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2ZM7 2a4 4 0 0 0-4 4v12a4 4 0 0 0 4 4h10a4 4 0 0 0 4-4V6a4 4 0 0 0-4-4H7Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M17 4H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2ZM7 2a4 4 0 0 0-4 4v12a4 4 0 0 0 4 4h10a4 4 0 0 0 4-4V6a4 4 0 0 0-4-4H7Z">
                                         </path>
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M7 8a1 1 0 0 1 1-1h8a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 12a1 1 0 0 1 1-1h8a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 16a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1Z">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M7 8a1 1 0 0 1 1-1h8a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 12a1 1 0 0 1 1-1h8a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM7 16a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1Z">
                                         </path>
                                     </svg>
                                 </span> 아티클
                             </button>
-                            <button class="sv813dg  " data-cy="side-nav-videos">
+                            <button class="sv813dg" data-cy="side-nav-videos">
                                 <span class="i1qqph0t icon side-nav-icon">
                                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                                        <rect width="18" height="18" x="3" y="3" stroke="currentColor" fill="none" stroke-width="2" rx="3">
+                                        <rect width="18" height="18" x="3" y="3" stroke="currentColor" fill="none"
+                                            stroke-width="2" rx="3">
                                         </rect>
-                                        <path fill="currentColor" d="M9 14.461V9.54a1 1 0 0 1 1.406-.914l5.538 2.461c.792.352.792 1.476 0 1.828l-5.538 2.461A1 1 0 0 1 9 14.461z">
+                                        <path fill="currentColor"
+                                            d="M9 14.461V9.54a1 1 0 0 1 1.406-.914l5.538 2.461c.792.352.792 1.476 0 1.828l-5.538 2.461A1 1 0 0 1 9 14.461z">
                                         </path>
                                     </svg>
                                 </span> 동영상
                             </button>
-                           <div class="s1jxyudr">태그
+                            <div class="s1jxyudr">태그
 
-                          </div>
-                
-                            <button class="sv813dg  " data-cy="side-nav-all-tags">
+                            </div>
+
+                            <button class="sv813dg" data-cy="side-nav-all-tags">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                       <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z">
-                                       </path>
-                                       <path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z">
-                                       </path>
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z">
+                                        </path>
+                                        <path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z">
+                                        </path>
                                     </svg>
                                 </span> 모든 태그
                             </button>
@@ -137,57 +169,49 @@
                         <div class="bottom-nav">
                             <button aria-label="맨 위로 돌아가기" class="visible" data-cy="side-nav-scroll-to-top">
                                 <span class="i1qqph0t icon">
-                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M19.707 14.707a1 1 0 0 1-1.414 0L12 8.414l-6.293 6.293a1 1 0 0 1-1.414-1.414l7-7a1 1 0 0 1 1.414 0l7 7a1 1 0 0 1 0 1.414Z">
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd"
+                                            d="M19.707 14.707a1 1 0 0 1-1.414 0L12 8.414l-6.293 6.293a1 1 0 0 1-1.414-1.414l7-7a1 1 0 0 1 1.414 0l7 7a1 1 0 0 1 0 1.414Z">
 
                                         </path>
                                     </svg>
                                 </span>
                             </button>
                         </div>
-                                
-                            </div>
-                            <main class="main">
-                                <header class="m1nf84in">
-                                    <h1 class="pageTitle" data-cy="page-title">내 목록</h1>
-                                    <div>
-                                        <button class="b5bt6fr s1xenxab" data-cy="sort-options">
-                                            <span class="i1qqph0t icon">
-                                                <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                                                    <path d="M8.707 6.707a1 1 0 0 0 0-1.414l-3-3a.999.999 0 0 0-1.414 0l-3 3a1 1 0 0 0 1.414 1.414L4 5.414V21a1 1 0 1 0 2 0V5.414l1.293 1.293a1 1 0 0 0 1.414 0ZM11 6a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H12a1 1 0 0 1-1-1ZM11 12a1 1 0 0 1 1-1h7a1 1 0 1 1 0 2h-7a1 1 0 0 1-1-1ZM11 18a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2h-4a1 1 0 0 1-1-1Z">
-                                                    </path>
-                                                </svg>
-                                            </span>
-                                        </button>
-                                    </div>
-                                </header>
-                                <div class="cmg9k0j grid" style="position: relative; pointer-events: auto;">
-                                    <div style="height: 2310px; padding-top: 0px;">
-                                        <div class="c1qfws8i">
-                                            
-                                    
-                        
-                        
-                    
-                
-                
-                
-                
-                        </div>
-                 </div>
-        
-             </div>
-        </main>
-</body>
-<div class="t1qdyznf">
 
-</div>
-</div>
-</div>
-</div>
+                    </div>
+                    <main class="main">
+                        <header class="m1nf84in">
+                            <h1 class="pageTitle" data-cy="page-title">내 목록</h1>
+                            <div>
+                                <button class="b5bt6fr s1xenxab" data-cy="sort-options">
+                                    <span class="i1qqph0t icon">
+                                        <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                                            aria-hidden="true">
+                                            <path
+                                                d="M8.707 6.707a1 1 0 0 0 0-1.414l-3-3a.999.999 0 0 0-1.414 0l-3 3a1 1 0 0 0 1.414 1.414L4 5.414V21a1 1 0 1 0 2 0V5.414l1.293 1.293a1 1 0 0 0 1.414 0ZM11 6a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H12a1 1 0 0 1-1-1ZM11 12a1 1 0 0 1 1-1h7a1 1 0 1 1 0 2h-7a1 1 0 0 1-1-1ZM11 18a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2h-4a1 1 0 0 1-1-1Z">
+                                            </path>
+                                        </svg>
+                                    </span>
+                                </button>
+                            </div>
+                        </header>
+                        <div class="cmg9k0j grid" style="position: relative; pointer-events: auto;">
+                            <div style="height: 2310px; padding-top: 0px;">
+                                <div class="c1qfws8i" id="root">
+                                   
+                                </div>
+                            </div>
+                        </div>
+                    </main>         
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
 <!-- FOOTER -->
 {% include 'mylist/footer.html' %}
 
 </div>
-
- 


### PR DESCRIPTION
## What about is this PR? 🔍
[FEAT: Add javascript, css for mylist/ url](https://github.com/backendnanodegree/Devket/pull/28/commits/df89d0db8427f71d827a51ed59deba70dec3ef2d) 
- javascript를 통해 '내 목록'에 저장된 항목들 보여주는 화면 구현하기 
    - '내 목록'에 보여지는 항목들 tag를 렌더링하는 javascript 추가  
- 각 항목을 hover 시, 밑에 '하단 툴바' 나타나도록 구현하기
    - javascript의 `.className` 을 사용하여 css가 적용되도록 구현 
- 하단 툴바 아이콘들이 화면에 나타나지 않아 태그 교체  -> javascript에 구현
- css에 mylist url 에 관련된 css가 많기 때문에, 별도의 directory를 만들어 옮김

[FEAT: edit mylist/base.html template for mylist/ url](https://github.com/backendnanodegree/Devket/pull/28/commits/6c7f4fb86293b2901b2d2dcf1115f0514100b02e)
- mylist/base.html 에 css link 수정 및 추가 
- mylist/base.html 에 javascript script tag 추가
- 항목이 추가되는 div tag (class name: c1qfws8i) 에 id tag(id name: root) 를 추가

<br>

## Change Logic 📝

[FEAT: Add javascript, css for mylist/ url](https://github.com/backendnanodegree/Devket/pull/28/commits/df89d0db8427f71d827a51ed59deba70dec3ef2d) 

### before
- mylist 화면에 dummy data로 저장된 항목들이 나타나지 않았다. 
- 하단 툴바의 아이콘 tag인 `<svg><path d=''></path></svg>`가 템플릿에 존재했지만, 화면 상에 아이콘이 나타나지 않았다.
    - path의 'd' 속성에 있는 svg 값이 인식되지 않았다. 이를 해결하기 위해서 기존 클론 코딩 대상과 비교하여 css 적용이 안된 것과 태그의 속성을 여러가지 추가해도 해결되지 않았다. 그래서 프로젝트 일정을 고려했을 때 다른 태그로 교체하는 게 시간적으로 보다 효율적이라는 판단을 내렸다. 

### after
- mylist 화면에 dummy data로 저장된 항목들이 나타난다.
- 그리고, 각 항목을 Hover 시, 하단 툴바가 뜨도록 수정했다. 
- 위 하단 툴바의 아이콘 tag가 나타나지 않아서 fontawesome의 아이콘으로 교체했다.
    - `<i class= '' /> `tag로 교체
    - fontawesome으로 선택한 이유는 다른 폰트 사이트들에 비해서 디자인적으로 제일 기존 아이콘과 유사했기 때문이다.
    - 아이콘을 별도의 파일로 저장하는 방식이 더 좋은 방식이지만, 이를 위해서는 유료 결제가 필요하므로 fontawesome script link를 추가하고, 태그를 추가하는 방식을 선택했다.

<br>

## To Reviewers 👂
- 위 error 내용 숙지 부탁드립니다.
