### PR TITLE
FEAT: Add api_url, view_url, View class

### DIFF
--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 from pocket.views import (
     HomeView, 
@@ -8,17 +8,30 @@ from pocket.views import (
     PwdHelpView, 
     PremiumView,
     PaymentView,
+    MyListView,
+    ListAPIView,
 )
+
+
+api_patterns = [
+    path('list/', ListAPIView.as_view()),
+]
 
 urlpatterns = [
     path('', HomeView.as_view(), name='home'),
-    
+
     # user
     path('signup/', SignUpView.as_view(), name='signup'),
     path('login/', LogInView.as_view(), name='login'),
     path('login/password/', PwdHelpView.as_view(), name='password'),
-    
+
+    #mylist
+    path('mylist/', MyListView.as_view(), name='mylist'), 
+
     # payment
     path('premium/', PremiumView.as_view(), name='premium'),
     path('premium/payment/', PaymentView.as_view(), name='payment'),
+
+    # api
+    path('api/', include(api_patterns)),
 ]

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -1,5 +1,9 @@
-from django.shortcuts import render
 from django.views.generic import TemplateView
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from .serializers import ListSerializer
+from .models import List
+
 class HomeView(TemplateView):
     template_name = "common/home.html"
 
@@ -40,3 +44,29 @@ class PaymentView(TemplateView):
 
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
+
+
+class MyListView(TemplateView):
+    """
+    mylist/base.html에 모든 항목들 리스트를 전달하는 함수
+    """
+
+    template_name: str = 'mylist/base.html'
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["lists"] = List.objects.all()
+        return context
+
+
+class ListAPIView(APIView):
+    """
+    저장한 모든 항목 데이터들을 api로 쏴주는 함수
+    """
+
+    def get(self, request): 
+        list_qs = List.objects.all()  
+        
+        serializer = ListSerializer(list_qs, many=True)
+
+        return Response(serializer.data)


### PR DESCRIPTION
## What about is this PR? 🔍
- mylist에 관한 api_url과 view_url 추가
- mylist에 관한 api_url를 만드는 ListAPIView 추가
- mylistd에 관한 view_url과 mapping 되는 view인 MyListView 추가

<br>

## Change Logic 📝

### before
- mylist에 관한 api_url이 존재하지 않았다.

### after
- mylist에 관한 api_url 추가
    - 이를 위해서 ListAPIView class 추가 

<br>

## To Reviewers 👂
- MyListView class의 경우, 단지 urlpatterns에 오류를 방지하기 위해 연결된 view class입니다. 그래서 get_context_data 함수의 내용을 단지 pass만 입력해도 잘 작동됩니다. 왜냐하면 데이터를 반환하는 것은 javascript에서 api를 받아서 보여주기 때문입니다.
```python
# 현재 코드 내용
class MyListView(TemplateView):
    template_name: str = 'mylist/base.html'

    def get_context_data(self, *args, **kwargs):
        context = super().get_context_data(**kwargs)
        context["lists"] = List.objects.all()
        return context

# 다음과 같이 수정해도 문제 x
class MyListView(TemplateView):
    template_name: str = 'mylist/base.html'

    def get_context_data(self, *args, **kwargs):
        pass
```

- 일단 class가 존재해야하기 때문에 추가하지만, 이 부분을 어떻게 해야 유용하게 변경할 수 있을지 봐주시면 좋겠습니다.