### PR TITLE
ADD: add save function and search function by toolbar

### DIFF
--- a/pocket/decorator.py
+++ b/pocket/decorator.py
@@ -9,7 +9,8 @@ def scrap_decorator(func):
 
     @wraps(func)
     def exec_func(self, request) -> func:
-        url: str = request.GET.get('url')
+        # path 파라미터 -> request body 파라미터로 절달 변경
+        url: str = self.request.data.get('url')
 
         if access(scheme(slash(url)), header): 
             # Issue : scheme가 붙어있지 않으면 파싱 불가

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -10,6 +10,7 @@ from django.db import transaction
 from bs4 import BeautifulSoup
 import requests
 
+from django.db.models import Q
 from .models import Site, User
 
 class HomeView(TemplateView):
@@ -78,9 +79,11 @@ class SiteAPIView(APIView):
     """
 
     def get(self, request): 
-
-        list_qs     = Site.objects.all()  
-        serializer  = SiteSerializer(list_qs, many=True)
+        word: str  = request.GET['word']              
+        list_qs    = Site.objects.filter(
+                        Q(title__contains=word)|
+                        Q(host_name__contains=word))  
+        serializer = SiteSerializer(list_qs, many=True)
 
         return Response(serializer.data)
 
@@ -105,10 +108,14 @@ class ArticleAPIView(APIView):
      Site model의 Video column 값이 false인 data를 api로 만드는 함수
     """
 
-    def get(self, request): 
-        list_qs     = Site.objects.filter(video=False)
-        
-        serializer  = SiteSerializer(list_qs, many=True)
+    def get(self, request):
+        word: str  = request.GET['word']   
+        list_qs    = Site.objects.filter(
+                            Q(video=False)&(
+                            Q(title__contains=word)|
+                            Q(host_name__contains=word)))
+
+        serializer = SiteSerializer(list_qs, many=True)
 
         return Response(serializer.data)
 
@@ -118,10 +125,14 @@ class VideoAPIView(APIView):
      Site model의 Video column 값이 True인 data를 api로 만드는 함수
     """
 
-    def get(self, request): 
-        list_qs     = Site.objects.filter(video=True)
-        
-        serializer  = SiteSerializer(list_qs, many=True)
+    def get(self, request):
+        word: str  = request.GET['word'] 
+        list_qs    = Site.objects.filter(
+                        Q(video=True)&(
+                        Q(title__contains=word)|
+                        Q(host_name__contains=word)))
+
+        serializer = SiteSerializer(list_qs, many=True)
 
         return Response(serializer.data)
 

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -125,17 +125,10 @@ class VideoAPIView(APIView):
 
         return Response(serializer.data)
 
-
-
-class Status():
-    OK = 'True'
-    NO = 'False'
-    ERROR = 'Error'        
-
-
+        
 class ParseAPIView(APIView):
     @scrap_decorator
-    def get(self, request, **kwards):
+    def post(self, request, **kwards):
         result: dict = {}
         video_type, title, image, url = '', '', '', ''
         try:
@@ -187,22 +180,22 @@ class ParseAPIView(APIView):
                             content         = content
                         )
 
-                    return Response({'msg':'Success save that web site', 'status':status.HTTP_200_OK})
+                    return Response({'msg':'Success save that web site'}, status=status.HTTP_200_OK)
 
                 else:
-                    return Response({'msg':'Do not save that web site', 'status':status.HTTP_202_ACCEPTED})
+                    return Response({'msg':'Do not save that web site'}, status=status.HTTP_202_ACCEPTED)
 
             else:
-                return Response({'msg':'Do not access that web site', 'status':status.HTTP_202_ACCEPTED})
+                return Response({'msg':'Do not access that web site'}, status=status.HTTP_202_ACCEPTED)
                                 
         except SyntaxError as s:
-            return Response({'msg':f'Save list process SyntaxError that Class ParseAPIView: {s.args}', 'status':status.HTTP_400_BAD_REQUEST})
+            return Response({'msg':f'Save list process SyntaxError that Class ParseAPIView: {s.args}'}, status=status.HTTP_400_BAD_REQUEST)
 
         except NameError as n:
-            return Response({'msg':f'Save list process NameError that Class ParseAPIView : {n.args}', 'status':status.HTTP_400_BAD_REQUEST})
+            return Response({'msg':f'Save list process NameError that Class ParseAPIView : {n.args}'}, status=status.HTTP_400_BAD_REQUEST)
             
         except KeyError as k:
-            return Response({'msg':f'Save list process KeyError that Class ParseAPIView : {k.args}', 'status':status.HTTP_400_BAD_REQUEST})
+            return Response({'msg':f'Save list process KeyError that Class ParseAPIView : {k.args}'}, status=status.HTTP_400_BAD_REQUEST)
 
     def parse(self, web: object) -> str:
         ''' 
@@ -213,6 +206,6 @@ class ParseAPIView(APIView):
             html: str = str(web.main)
 
         except Exception as e:       
-            raise RuntimeError('Function parse Exception error that Class ParseAPIView : {e.args}')
+            raise RuntimeError(f'Function parse Exception error that Class ParseAPIView : {e.args}')
         
         return html

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -49,6 +49,14 @@ function appendTag(parent, element) {
     return parent.appendChild(element);
 }
 
+function removeAllNode(element) {
+    /* 요소의 내부 요소 초기화 */
+
+    while (element.hasChildNodes()) {
+        element.removeChild(element.firstChild);
+    }
+}
+
 function getCookie(name) {
     /* 이름값의 cookie 값 가져오기 */
 
@@ -192,6 +200,7 @@ export {
     removeElement,
     createNode, 
     appendTag,
+    removeAllNode,
     getCookie, 
     makeBottomToolbar
 };

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -49,6 +49,26 @@ function appendTag(parent, element) {
     return parent.appendChild(element);
 }
 
+function getCookie(name) {
+    /* 이름값의 cookie 값 가져오기 */
+
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+
+        const cookies = document.cookie.split(';');
+
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim();
+            
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
 function makeFavoriteInToolBar(parentNode) {
     /* 하단 툴바의 즐겨찾기 버튼 Dom을 만드는 함수 */
 
@@ -171,6 +191,7 @@ export {
     makeElementOn, 
     removeElement,
     createNode, 
-    appendTag, 
+    appendTag,
+    getCookie, 
     makeBottomToolbar
 };

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -45,8 +45,9 @@ function renderItem(post) {
 
     const publisher     = createNode('a')
     publisher.className = 'publisher'
-    publisher.href      = 'https://www.theatlantic.com/technology/archive/2022/10/phone-call-greeting-smartphone-technological-error/671910/?utm_source=pocket_saves'
-    publisher.innerText = 'The Atlantic'
+    publisher.href      = post.url == null ? '#' : post.url
+    publisher.innerText = post.host_name
+    publisher.setAttribute('target', post.url == null ? '' : '_blank')
     appendTag(details, publisher)
 
     // 각 항목(item)의 하단 툴바
@@ -80,11 +81,11 @@ function makeActive() {
     }
     
     // 선택한 태그만 활성화
-    tabName.className += ' active';
+    tabName.classList.add('active')
    
   }
 
-function getSiteList() {
+function getSiteList(word='') {
     /* 각 탭에 해당되는 모든 항목들을 조회하여 함수 */
     
     // 선택한 탭 활성화하기  
@@ -94,15 +95,14 @@ function getSiteList() {
     const url = window.location.pathname.split('/');
     const apiUrlKey = url.filter((element) => element != "").pop();
 
-    fetch(`${apiURL[apiUrlKey]}`)
-    .then(response => response.json())
-    .then(data => {
-        mapPosts(data)
-    })
-    .catch(err => {
-        console.log(err);
-    })
-
+    fetch(`${apiURL[apiUrlKey]}?word=${word}`)
+        .then(response => response.json())
+        .then(data => {
+            mapPosts(data)
+        })
+        .catch(err => {
+            console.log(err);
+        })
 }
 
 getSiteList()

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -1,4 +1,4 @@
-import {createNode, appendTag, makeBottomToolbar} from './common.js';
+import {createNode, appendTag, makeBottomToolbar, removeAllNode} from './common.js';
 import { apiURL } from './api-url.js';
 
 const root = document.getElementById("root")
@@ -57,6 +57,9 @@ function renderItem(post) {
 function mapPosts(data) {
     /* 각 데이터를 renderPost에 전달하여 rendering하는 함수 */
 
+    // root 모든 요소 초기화
+    removeAllNode(root)
+
     return data.map(item => {
         renderItem(item);
     })
@@ -103,3 +106,7 @@ function getSiteList() {
 }
 
 getSiteList()
+
+export {
+    getSiteList
+};

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -1,4 +1,5 @@
 import {getElement, getElements, makeElementOff, makeElementOn, removeElement, createNode, appendTag, getCookie} from './common.js';
+import {getSiteList} from './get-site-list.js';
 
 function makeSearchTopToolBar() {
     /* 검색 toolbar 생성 함수 */
@@ -81,7 +82,11 @@ function makeSearchTopToolBar() {
     mobileSearchText.textContent    = '취소'
     appendTag(mobileSearchFont, mobileSearchText)
 
+    searchInput.focus()
+
     toolbarCancelBtn()
+
+    searchSitebyToolbar()
 }
 
 function makeSaveTopToolBar() {
@@ -165,6 +170,8 @@ function makeSaveTopToolBar() {
     mobileSaveText.style            = 'vertical-align: inherit;'
     mobileSaveText.textContent      = '취소'
     appendTag(mobileSaveFont, mobileSaveText)
+
+    saveInput.focus()
 
     toolbarCancelBtn()
 
@@ -346,30 +353,57 @@ function toolbarCancelBtn () {
 function saveSitebyToolbar () {
     /* toolbar URL 저장 클릭 이벤트 */
 
-    const btnToolbarSave = getElement('.add-button');
+    const toolbarSaveBtn = getElement('.add-button');
 
-    btnToolbarSave.addEventListener('click', () => {
+    toolbarSaveBtn.addEventListener('click', () => {
 
         const csrftoken = getCookie('csrftoken');
-        let inputUrlValue = getElement('.add-input').value;
+        let url         = getElement('.add-input').value;
+        let regex       = /^(http(s)?:\/\/)([^\/]*)(\.)(com|net|kr|my|shop|info|site|io)(\/)/gi
 
-        const data = {
-            method: "POST",
-            headers: {
-                'content-type': 'application/json',
-                'X-CSRFToken' : csrftoken,
-
-            },
-            body: JSON.stringify({
-                url: inputUrlValue,
-                id : 'User Id' 
-            })
+        if(regex.test(url)){
+            const data = {
+                method: "POST",
+                headers: {
+                    'content-type': 'application/json',
+                    'X-CSRFToken' : csrftoken,        
+                },
+                body: JSON.stringify({
+                    url: url,
+                    id : 'User Id' 
+                })
+            }
+            
+            fetch(`/api/scrap/parse/`, data)
+                .then(response => {
+                    let status = response.status
+                    if (status === 200) {
+                        alert('저장에 성공하였습니다.')
+                    }else if (status === 202) {
+                        alert('저장할 수 없는 사이트입니다.')
+                    }else if (status === 400) {
+                        alert(response.json.msg)
+                    }
+                    return response.json()
+                })
+                // 조회함수 호출
+                .then(result => getSiteList()) 
+                .catch(error => console.log(error))
+        }else{
+            alert('형식에 맞는 url을 입력바랍니다. (http://... or https://...)')
         }
-        
-        fetch(`/api/scrap/parse/`, data)
-            .then(response  => response.json())
-            .then(result    => console.log(result))
-            .catch(error    => console.log(error))
+    })
+}
+
+function searchSitebyToolbar () {
+    /* toolbar title 조회 클릭 이벤트*/
+
+    const searchToolbarBtn = getElement('.search-button');
+
+    searchToolbarBtn.addEventListener('click', () => {
+        let word = getElement('.search-input').value;
+
+        getSiteList(word)
     })
 }
 

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -1,9 +1,9 @@
-import {getElement, getElements, makeElementOff, makeElementOn, removeElement, createNode, appendTag, makeBottomToolbar} from './common.js';
+import {getElement, getElements, makeElementOff, makeElementOn, removeElement, createNode, appendTag, getCookie} from './common.js';
 
 function makeSearchTopToolBar() {
     /* 검색 toolbar 생성 함수 */
 
-    const searchForm                = createNode('form')
+    const searchForm                = createNode('div')
     searchForm.className            = 'sxpxhia toolbar-container'
     searchForm.autocomplete         = 'off'
     appendTag(headerContainer, searchForm)
@@ -87,7 +87,7 @@ function makeSearchTopToolBar() {
 function makeSaveTopToolBar() {
     /* 저장 toolbar 생성 함수 */
 
-    const saveForm                  = createNode('form')
+    const saveForm                  = createNode('div')
     saveForm.className              = 'a14hwmit toolbar-container'
     saveForm.autocomplete           = 'off'
     appendTag(headerContainer, saveForm)
@@ -167,9 +167,13 @@ function makeSaveTopToolBar() {
     appendTag(mobileSaveFont, mobileSaveText)
 
     toolbarCancelBtn()
+
+    saveSitebyToolbar()
 }
 
 function makeBulkTopToolBar() {
+    /* 벌크 toolbar 생성 함수 */
+
     const bulkWrap                      = createNode('div')
     bulkWrap.className                  = 'b1xsx9mu toolbar-container'
     appendTag(headerContainer, bulkWrap)
@@ -284,8 +288,8 @@ function makeBulkTopToolBar() {
     bulkCancleButton.setAttribute('data-cy', 'clear-button')
     appendTag(bulkInnerWrap, bulkCancleButton)
     
-    const bulkCancleButtonFont              = createNode('font')
-    bulkCancleButtonFont.style              = 'vertical-align: inherit;'
+    const bulkCancleButtonFont          = createNode('font')
+    bulkCancleButtonFont.style          = 'vertical-align: inherit;'
     appendTag(bulkCancleButton, bulkCancleButtonFont)
     
     const mobileItemSelectText          = createNode('font')
@@ -326,6 +330,8 @@ function makeBulkTopToolBar() {
 }
 
 function toolbarCancelBtn () {
+    /* toolbar 닫기 클릭 이벤트 */
+
     const btnCancels                    = getElements('.toolbar-cancel');
     const toolbarContainer              = getElement('.toolbar-container');
 
@@ -334,6 +340,36 @@ function toolbarCancelBtn () {
             makeElementOn(menuContainer, toolContainer, profileContainer)
             removeElement(toolbarContainer)
         })
+    })
+}
+
+function saveSitebyToolbar () {
+    /* toolbar URL 저장 클릭 이벤트 */
+
+    const btnToolbarSave = getElement('.add-button');
+
+    btnToolbarSave.addEventListener('click', () => {
+
+        const csrftoken = getCookie('csrftoken');
+        let inputUrlValue = getElement('.add-input').value;
+
+        const data = {
+            method: "POST",
+            headers: {
+                'content-type': 'application/json',
+                'X-CSRFToken' : csrftoken,
+
+            },
+            body: JSON.stringify({
+                url: inputUrlValue,
+                id : 'User Id' 
+            })
+        }
+        
+        fetch(`/api/scrap/parse/`, data)
+            .then(response  => response.json())
+            .then(result    => console.log(result))
+            .catch(error    => console.log(error))
     })
 }
 

--- a/templates/mylist/base.html
+++ b/templates/mylist/base.html
@@ -160,7 +160,7 @@
                             </div>
                         </header>
                         <div class="cmg9k0j grid" style="position: relative; pointer-events: auto;">
-                            <div style="height: 2310px; padding-top: 0px;">
+                            <div style="height: 100%; padding-top: 0px;">
                                 <div class="c1qfws8i" id="root">
                                    
                                 </div>


### PR DESCRIPTION
## What about is this PR? 🔍
- 웹 사이트 파싱 api get->post 방식으로 변경
- 필요하지 않은 class Status 제거
- 공통함수(요소 내부 초기화, 쿠키 값 가져오기) 추가
- 사이트 데이터 조회 시 host_name 칼럼 조회 추가
- 사이트 데이터 조회 전 데이터 바인딩 여역인 root 요소 내부 초기화 추가
- 사이트 데이터 조회 함수에 검색 조건 word 추가
- 툴바 저장 함수, 조회 함수 추가
- root요소의 부모 div height 100% 변경

<br>

## Change Logic 📝

### before
- 웹 사이트 파싱 api를 get방식에 path 파라미터를 이용하여 데이터 저장
- response의 상태 값을 class Status()로 설정
- mylist 화면 데이터 조회 시 초기 데이터 초기화 설정이 없음
- tabName부분 active 클래스를 부여할때 className += ' active' 방식으로 설정되어 있음

### after
- 데이터 저장을 restful하게 변경하기위해 post방식으로 변경하였으며 파라미터를 request body 파라미터로 변경
- response의 상태 값을 rest_framework의 status로 설정하게 변경
- common.js에 공통함수 2개 추가
    - removeAllNode() : 요소 내부의 모든 요소 초기화 함수
    - getCookie()          : cookie 가져오기 함수 
- 사이트 데이터 조회 시 하단 publisher 부분에 url과 host_name값을 바인딩하여 출처를 표시 및 클릭 시 새창으로 이동할 수 있게 a 링크 연결(target='_blank' 속성 사용)
```python
<a href='' target='_blank'>
```
- mylist 화면 데이터 조회 시 데이터가 누적되어 조회되지 않게 데이터 초기화 설정
```python
function mapPosts(data) {
        /* 각 데이터를 renderPost에 전달하여 rendering하는 함수 */
    
        // root 모든 요소 초기화
        removeAllNode(root)
    
        return data.map(item => {
            renderItem(item);
        })
    }
```
- tabName부분 active 클래스를 부여할때 classList.add('active') 방식으로 변경
- Toolbar 저장 함수 saveSitebyToolbar() 추가
- Toolbar 조회 함수 searchSitebyToolbar() 추가
<br>

## To Reviewers 👂
- 서로 동일한 화면을 수정하고 있어 충돌이 날것 같은 부분은 말씀해주세요


<br>