### PR TITLE
Modifiy api-url and add delete function by bottom-toolbar

### DIFF
--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -2,29 +2,32 @@ from django.contrib import admin
 from django.urls import path, include
 
 from pocket.views import (
-    HomeView, 
-    ParseAPIView, 
-    SignUpView, 
-    LogInView, 
-    PwdHelpView, 
-    PremiumView,
-    PaymentView,
-    MyListView,
+    # api_view
+    ParseAPIView,
     SiteAPIView,
     SiteDetailAPIView,
     FavoriteAPIView, 
     ArticleAPIView, 
     VideoAPIView,
 
+    # template_view
+    HomeView,
+    mylist_view, 
+    SignUpView, 
+    LogInView, 
+    PwdHelpView, 
+    PremiumView,
+    PaymentView,
+
 )
 
 api_patterns = [
-    path('sites/', SiteAPIView.as_view()),
-    path('sites/<int:pk>/', SiteDetailAPIView.as_view()),
-    path('scrap/parse/', ParseAPIView.as_view()), 
-    path('favorites/', FavoriteAPIView.as_view()),
-    path('articles/', ArticleAPIView.as_view()),
-    path('videos/', VideoAPIView.as_view()),
+    path('scrap/parse', ParseAPIView.as_view()), 
+    path('sites', SiteAPIView.as_view()),
+    path('sites/<int:pk>', SiteDetailAPIView.as_view()),
+    path('favorites', FavoriteAPIView.as_view()),
+    path('articles', ArticleAPIView.as_view()),
+    path('videos', VideoAPIView.as_view()),
 ]
 
 urlpatterns = [
@@ -35,11 +38,11 @@ urlpatterns = [
     path('login/', LogInView.as_view(), name='login'),
     path('login/password/', PwdHelpView.as_view(), name='password'),
 
-    #mylist
-    path('mylist/', MyListView.as_view(), name='mylist'), 
-    path('mylist/favorites/', MyListView.as_view(), name='favorites'), 
-    path('mylist/articles/', MyListView.as_view(), name='articles'), 
-    path('mylist/videos/', MyListView.as_view(), name='videos'), 
+    # mylist
+    path('mylist/', mylist_view, name='mylist'), 
+    path('mylist/favorites/', mylist_view, name='favorites'), 
+    path('mylist/articles/', mylist_view, name='articles'), 
+    path('mylist/videos/', mylist_view, name='videos'), 
 
     # payment
     path('premium/', PremiumView.as_view(), name='premium'),
@@ -47,5 +50,4 @@ urlpatterns = [
 
     # api
     path('api/', include(api_patterns)),
-
 ]

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -1,18 +1,29 @@
+from django.shortcuts import get_object_or_404, render
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from django.shortcuts import get_object_or_404
 from rest_framework import status
 
 from pocket.decorator import scrap_decorator
 from .serializers import SiteSerializer
 from urllib.parse import urlparse
 from django.db import transaction
+from django.db.models import Q
+from .models import Site, User
 from bs4 import BeautifulSoup
 import requests
 
-from django.db.models import Q
-from .models import Site, User
+# template view
+
+def mylist_view(request):
+
+    """
+    mylist/base.html에 모든 항목들 리스트를 전달하는 함수
+    """
+    if request.method == 'GET': 
+
+        return render(request, 'mylist/base.html')
 
 class HomeView(TemplateView):
     template_name = "common/home.html"
@@ -58,21 +69,8 @@ class PaymentView(TemplateView):
         return super().get(request, *args, **kwargs)
 
 
-class MyListView(TemplateView):
-    """
-    mylist/base.html에 모든 항목들 리스트를 전달하는 함수
-    """
 
-    template_name: str = 'mylist/base.html'
-
-    def get_context_data(self, *args, **kwargs):
-
-        context             = super().get_context_data(**kwargs)
-        context["lists"]    = Site.objects.all()
-
-        return context
-
-
+# api view
 class SiteAPIView(APIView):
     """
     저장한 모든 항목 데이터들을 api로 쏴주는 함수
@@ -113,9 +111,9 @@ class SiteDetailAPIView(APIView):
         site = self.get_object(pk)
 
         serializer = SiteSerializer(site, data=request.data, partial=True)
- 
+    
         if serializer.is_valid(raise_exception=True):
-           
+     
             serializer.save()
             
             return Response({'msg':'Updated successfully'}, status=status.HTTP_202_ACCEPTED)
@@ -128,7 +126,7 @@ class SiteDetailAPIView(APIView):
         site = self.get_object(pk)
         
         site.delete()
-
+    
         return Response({'msg': 'Deleted successfully'}, status=status.HTTP_200_OK)
        
 

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -1,0 +1,153 @@
+.m1gbisw7 {
+    position: absolute;
+    overflow: auto;
+    overflow-x: hidden;
+    max-width: 552px;
+    padding: 0;
+    background: var(--color-popoverCanvas);
+    margin: 0 auto;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    box-sizing: border-box;
+    box-shadow: 0 var(--spacing150) 32px rgba(0, 0, 0, 0.16);
+    border-radius: 4px;
+    max-height: calc(100vh - (calc(var(--spacing650) + var(--spacing400))));
+    min-height: 200px;
+    top: var(--spacing650);
+    right: var(--spacing400);
+    bottom: auto;
+    left: var(--spacing400);
+    z-index: var(--zIndexModal);
+    -webkit-transition: opacity var(--dialogsDurationExitMS) var(--easingDecelerate), -webkit-transform var(--dialogsDurationExitMS) var(--easingDecelerate);
+    -webkit-transition: opacity var(--dialogsDurationExitMS) var(--easingDecelerate), transform var(--dialogsDurationExitMS) var(--easingDecelerate);
+    transition: opacity var(--dialogsDurationExitMS) var(--easingDecelerate), transform var(--dialogsDurationExitMS) var(--easingDecelerate);
+}
+
+.m1gbisw7.animation-base {
+    pointer-events: none;
+    opacity: 0;
+    -webkit-transform: scale(0.8);
+    -ms-transform: scale(0.8);
+    transform: scale(0.8);
+}
+
+.m1gbisw7.animation-show {
+    pointer-events: auto;
+    opacity: 1;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+    -webkit-transition: opacity var(--dialogsDurationEnterMS) var(--easingAccelerate), -webkit-transform var(--dialogsDurationEnterMS) var(--easingAccelerate);
+    -webkit-transition: opacity var(--dialogsDurationEnterMS) var(--easingAccelerate), transform var(--dialogsDurationEnterMS) var(--easingAccelerate);
+    transition: opacity var(--dialogsDurationEnterMS) var(--easingAccelerate), transform var(--dialogsDurationEnterMS) var(--easingAccelerate);
+}
+
+.m1gbisw7.animation-hide {
+    opacity: 0;
+}
+
+@media (max-width:1279px) {
+    .m1gbisw7 {
+        max-height: calc(100vh - (calc(var(--spacing400) * 2)));
+        top: var(--spacing400);
+    }
+}
+
+@media (max-width:719px) {
+    .m1gbisw7 {
+        left: var(--spacing150);
+        right: var(--spacing150);
+    }
+}
+
+@media (max-width:599px) {
+    .m1gbisw7 {
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: auto;
+        border-radius: 0;
+        max-height: calc(100vh - var(--spacing650));
+        max-width: 100%;
+        -webkit-transform-origin: bottom;
+        -ms-transform-origin: bottom;
+        transform-origin: bottom;
+    }
+
+    .m1gbisw7.animation-base {
+        -webkit-transform: scale(1) translateY(20%);
+        -ms-transform: scale(1) translateY(20%);
+        transform: scale(1) translateY(20%);
+    }
+
+    .m1gbisw7.animation-show {
+        -webkit-transform: scale(1) translateY(0);
+        -ms-transform: scale(1) translateY(0);
+        transform: scale(1) translateY(0);
+        -webkit-transition-property: opacity, -webkit-transform;
+        -webkit-transition-property: opacity, transform;
+        transition-property: opacity, transform;
+    }
+}
+
+.m1gbisw7.force-mobile {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: auto;
+    border-radius: 0;
+    max-height: calc(100vh - var(--spacing650));
+    max-width: 100%;
+    -webkit-transform-origin: bottom;
+    -ms-transform-origin: bottom;
+    transform-origin: bottom;
+}
+
+.m1gbisw7.force-mobile.animation-base {
+    -webkit-transform: scale(1) translateY(20%);
+    -ms-transform: scale(1) translateY(20%);
+    transform: scale(1) translateY(20%);
+}
+
+.m1gbisw7.force-mobile.animation-show {
+    -webkit-transform: scale(1) translateY(0);
+    -ms-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+    -webkit-transition-property: opacity, -webkit-transform;
+    -webkit-transition-property: opacity, transform;
+    transition-property: opacity, transform;
+}
+
+body.modal-open {
+    overflow: hidden;
+}
+
+.o1ohlj7h {
+    position: fixed;
+    background: rgba(26, 26, 26, 0.24) none repeat scroll 0 0;
+    mix-blend-mode: normal;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: var(--zIndexModalShade);
+    -webkit-transition: opacity var(--dialogsDurationExitMS) var(--easingAccelerate), -webkit-transform var(--dialogsDurationExitMS) var(--easingAccelerate);
+    -webkit-transition: opacity var(--dialogsDurationExitMS) var(--easingAccelerate), transform var(--dialogsDurationExitMS) var(--easingAccelerate);
+    transition: opacity var(--dialogsDurationExitMS) var(--easingAccelerate), transform var(--dialogsDurationExitMS) var(--easingAccelerate);
+}
+
+.o1ohlj7h.animation-base {
+    pointer-events: none;
+    opacity: 0;
+}
+
+.o1ohlj7h.animation-show {
+    pointer-events: auto;
+    opacity: 1;
+    -webkit-transition: opacity var(--dialogsDurationEnterMS) var(--easingDecelerate), -webkit-transform var(--dialogsDurationEnterMS) var(--easingDecelerate);
+    -webkit-transition: opacity var(--dialogsDurationEnterMS) var(--easingDecelerate), transform var(--dialogsDurationEnterMS) var(--easingDecelerate);
+    transition: opacity var(--dialogsDurationEnterMS) var(--easingDecelerate), transform var(--dialogsDurationEnterMS) var(--easingDecelerate);
+}
+
+.o1ohlj7h.animation-hide {
+    opacity: 0;
+}å

--- a/static/js/api-url.js
+++ b/static/js/api-url.js
@@ -1,10 +1,10 @@
 const apiURL = {
-    'mylist' : '/api/sites/',
-    'categories' : '/api/category/',
-    'favorites' : '/api/favorites/',
-    'highlights' : '/api/',
-    'articles' : '/api/articles/',
-    'videos' : '/api/videos/',
+    'mylist' : '/api/sites',
+    'categories' : '/api/category',
+    'favorites' : '/api/favorites',
+    'highlights' : '/api/highlights',
+    'articles' : '/api/articles',
+    'videos' : '/api/videos',
 }
 
 export {apiURL}

--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -1,15 +1,15 @@
-import { createNode, appendTag, getCookie } from "./common.js"
+import { createNode, appendTag, getCookie, getElement } from "./common.js"
+import { openModal } from "./modal.js"
 
-
-function makeFavoriteInToolBar(parentNode, post) {
+function makeFavoriteInToolBar(parentNode, site) {
     /* 하단 툴바의 즐겨찾기 버튼 Dom을 만드는 함수 */
 
     const favoriteButtonContainer   = createNode('span')
     appendTag(parentNode, favoriteButtonContainer)
 
     const favoriteButton        = createNode('button')
-    favoriteButton.className    = post.favorite == false ? 'm11fpiro t1221eea pmdugmx d1mp5exd' : 'm11fpiro t1221eea pmdugmx d1mp5exd active'
-    favoriteButton.setAttribute('data-tooltip', post.favorite == false ? '즐겨찾기' : '즐겨찾기 해제')
+    favoriteButton.className    = site.favorite == false ? 'm11fpiro t1221eea pmdugmx d1mp5exd favorite' : 'm11fpiro t1221eea pmdugmx d1mp5exd favorite active'
+    favoriteButton.setAttribute('data-tooltip', site.favorite == false ? '즐겨찾기' : '즐겨찾기 해제')
     appendTag(favoriteButtonContainer, favoriteButton)
 
     const favoriteIconContainer     = createNode('span')
@@ -20,18 +20,18 @@ function makeFavoriteInToolBar(parentNode, post) {
     favoriteIcon.className  = 'fa-regular fa-star fa-lg'
     appendTag(favoriteIconContainer, favoriteIcon)
 
-    changeFavoriteValue(favoriteButton, post)
+    changeFavoriteValue(favoriteButton, site)
 
 }
 
-function makeCategoryInToolBar(parentNode, post) {
+function makeCategoryInToolBar(parentNode, site) {
     /* 하단 툴바의 category button Dom을 만드는 함수 */
 
     const categoryButtonContainer   = createNode('span')
     appendTag(parentNode, categoryButtonContainer)
 
     const categoryButton        = createNode('button')
-    categoryButton.className    = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    categoryButton.className    = 'm11fpiro t1221eea pmdugmx d1mp5exd category'
     categoryButton.setAttribute('data-tooltip', '카테고리')
     appendTag(categoryButtonContainer, categoryButton)
 
@@ -45,14 +45,14 @@ function makeCategoryInToolBar(parentNode, post) {
 
 }
 
-function makeTagInToolBar(itemActions, post) {
+function makeTagInToolBar(parentNode, site) {
     /* 하단 툴바의 tag button Dom을 만드는 함수 */
 
     const tagButtonContainer    = createNode('span')
-    appendTag(itemActions, tagButtonContainer)
+    appendTag(parentNode, tagButtonContainer)
 
     const tagButton     = createNode('button')
-    tagButton.className = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    tagButton.className = 'm11fpiro t1221eea pmdugmx d1mp5exd tag'
     tagButton.setAttribute('data-tooltip', '태그')
     appendTag(tagButtonContainer, tagButton)
 
@@ -67,14 +67,14 @@ function makeTagInToolBar(itemActions, post) {
 
 }
 
-function makeDeleteInToolBar(parentNode, post) {
+function makeDeleteInToolBar(parentNode, site) {
      /* 하단 툴바의 delete button Dom을 만드는 함수 */
 
     const deleteButtonContainer = createNode('span')
     appendTag(parentNode, deleteButtonContainer)
 
     const deleteButton      = createNode('button')
-    deleteButton.className  = 'm11fpiro t1221eea pmdugmx d1mp5exd'
+    deleteButton.className  = 'm11fpiro t1221eea pmdugmx d1mp5exd delete'
     deleteButton.setAttribute('data-tooltip', '삭제')
     appendTag(deleteButtonContainer, deleteButton)
 
@@ -82,14 +82,20 @@ function makeDeleteInToolBar(parentNode, post) {
     deleteIconContainer.className   = 'i1qqph0t icon'
     appendTag(deleteButton, deleteIconContainer)
 
-
     const deleteIcon        = createNode('i')
     deleteIcon.className    = 'fa fa-regular fa-trash fa-lg'
     appendTag(deleteIconContainer, deleteIcon)
 
+    // click 시, modal 창 열기
+    deleteButton.addEventListener('click', () => {
+        const article = document.getElementById(`${site.id}`)
+        article.classList.add('selected')
+        openModal(deleteButton)
+    })
+
 }
 
-function makeBottomToolbar(parentNode, post) {
+function makeBottomToolbar(parentNode, site) {
     /*각 항목마다 하단 툴바를 만드는 함수*/
 
      // bottom toolbar container - footer
@@ -106,39 +112,41 @@ function makeBottomToolbar(parentNode, post) {
      appendTag(itemActionsContainer, itemActions)
  
      // bottom toolbar - favorite
-     makeFavoriteInToolBar(itemActions, post)
+     makeFavoriteInToolBar(itemActions, site)
     
      // bottom toolbar - category
-     makeCategoryInToolBar(itemActions, post)
+     makeCategoryInToolBar(itemActions, site)
  
      // bottom toolbar - tag
-     makeTagInToolBar(itemActions, post)
+     makeTagInToolBar(itemActions, site)
  
      // bottom toolbar - delete
-     makeDeleteInToolBar(itemActions, post)
+     makeDeleteInToolBar(itemActions, site)
 }
 
-function changeFavoriteValue(favoriteButton, post) {
+function changeFavoriteValue(favoriteButton, site) {
     /* 하단 툴바의 즐겨찾기 버튼 상태 변경에 따른 즐겨찾기 목록에 추가 및 제거 */
 
     favoriteButton.addEventListener('click', () => {
 
         // 하단 툴바의 즐겨찾기 버튼 활성화 및 즐겨찾기 목록에 추가
-        const csrftoken     = getCookie('csrftoken');
+        const csrftoken         = getCookie('csrftoken');
+
         if (favoriteButton.classList.contains('active') == false) {
           
             // PUT: favorite 값 True로 수정
-          const data          = {
-              method: 'PUT',
-              headers: {
-                  'content-type': 'application/json',
-                  'X-CSRFToken' : csrftoken,  
-                },
-                body: JSON.stringify({
-                    favorite: true,
-                })
-            }
-            fetch(`/api/sites/${post.id}/`, data)
+            const data          = {
+                                    method: 'PUT',
+                                    headers: {
+                                        'content-type': 'application/json',
+                                        'X-CSRFToken' : csrftoken,  
+                                        },
+                                        body: JSON.stringify({
+                                            favorite: true,
+                                        })
+                                    }
+
+            fetch(`/api/sites/${site.id}`, data)
             .then(response => {
                 let status = response.status
 
@@ -166,9 +174,11 @@ function changeFavoriteValue(favoriteButton, post) {
                                         'favorite': false,
                                     })
                                 }
-            fetch(`/api/sites/${post.id}/`, data)
+
+            fetch(`/api/sites/${site.id}`, data)
             .then(response => {
-                let status = response.status
+
+                let status      = response.status
 
                 // 하단 툴바의 즐겨찾기 버튼 비활성화
                 if (status === 202) {
@@ -186,5 +196,5 @@ function changeFavoriteValue(favoriteButton, post) {
 }
 
 export {
-    makeBottomToolbar
+    makeBottomToolbar,
 }

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -1,16 +1,18 @@
 import {createNode, appendTag, getElement, removeAllNode} from './common.js';
 import { makeBottomToolbar } from './bottom-toolbar.js';
+import { makeModal } from './modal.js';
 import { apiURL } from './api-url.js';
 
 const root          = document.getElementById("root")
 const url           = window.location.pathname.split('/');
 const apiUrlKey     = url.filter((element) => element != "").pop();
 
-function renderItem(post) {
+function renderItem(site) {
     /* 각 item의 tag를 rendering 하는 함수 */
 
     const article               = createNode('article')
     article.className           = 'c18o9ext grid hiddenActions noExcerpt'
+    article.id                  = site.id 
     appendTag(root, article)
 
     const item                  = createNode('div')
@@ -22,11 +24,11 @@ function renderItem(post) {
     appendTag(item, imgContainer)
 
     const itemLink              = createNode('a')
-    itemLink.href               = post.thumbnail_url
+    itemLink.href               = site.thumbnail_url
     appendTag(imgContainer, itemLink)
 
     const img                   = createNode('img')
-    img.src                     = post.thumbnail_url
+    img.src                     = site.thumbnail_url
     img.style                   = '--fallbackBackground:#1CB0A880; --fallbackColor:#1CB0A8; --fallbackLetter:&quot;T&quot;;">'
     appendTag(itemLink, img)
 
@@ -39,7 +41,7 @@ function renderItem(post) {
     appendTag(content, titleContainer)
 
     const title                 = createNode('a')
-    title.innerText             = post.title
+    title.innerText             = site.title
     appendTag(titleContainer, title)
 
     const details               = createNode('cite')
@@ -48,13 +50,13 @@ function renderItem(post) {
 
     const publisher             = createNode('a')
     publisher.className         = 'publisher'
-    publisher.href              = post.url == null ? '#' : post.url
-    publisher.innerText         = post.host_name
-    publisher.setAttribute('target', post.url == null ? '' : '_blank')
+    publisher.href              = site.url == null ? '#' : site.url
+    publisher.innerText         = site.host_name
+    publisher.setAttribute('target', site.url == null ? '' : '_blank')
     appendTag(details, publisher)
 
     // 각 항목(item)의 하단 툴바
-    makeBottomToolbar(article, post)
+    makeBottomToolbar(article, site)
    
 }
 
@@ -118,6 +120,7 @@ function getSiteList(word='') {
 }
 
 getSiteList()
+makeModal()
 
 export {
     getSiteList

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,0 +1,147 @@
+import { createNode, appendTag, getElement, getCookie } from './common.js';
+
+function makeModal() {
+    /* modal 창 만들기 */
+
+    const next                      = getElement('#__next')
+    next.setAttribute('aria-hidden','true')
+
+    const modalOverlay              = createNode('div')
+    modalOverlay.className          = "ReactModal__Overlay ReactModal__Overlay--after-open o1ohlj7h animation-base"
+    modalOverlay.setAttribute('display', 'none')
+    appendTag(next, modalOverlay)
+
+    const modalContent              = createNode('div')
+    modalContent.className          = "ReactModal__Content ReactModal__Content--after-open m1gbisw7 animation-base animation-show"
+    modalContent.tabindex           = '-1'
+    modalContent.role               = 'dialog'
+    modalContent.setAttribute('aria-label', '항목 삭제')
+    modalContent.setAttribute('aria-modal', 'true')
+    appendTag(modalOverlay, modalContent)
+
+    const btnContainer              = createNode('div')
+    appendTag(modalContent, btnContainer)
+
+    // modal 창 닫기 버튼
+    const closeBtn                  = createNode('button')
+    closeBtn.className              = 'close c16lr040'
+    closeBtn.setAttribute('aria-label', '닫기')
+    appendTag(btnContainer, closeBtn)
+
+    const closeBtnIconContainer     = createNode('span')
+    closeBtnIconContainer.className = 'i1qqph0t icon'
+    appendTag(closeBtn, closeBtnIconContainer)
+
+    let closeIconSvgHTML            = `<svg class='close-icon-svg' fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>`
+    closeBtnIconContainer.insertAdjacentHTML('beforeend', closeIconSvgHTML)
+    const closeIconSvg              = getElement('.close-icon-svg')
+    
+    let iconPathHTML                = `<path fill-rule="evenodd" clip-rule="evenodd" d="M4.293 4.293a1 1 0 0 1 1.414 0L12 10.586l6.293-6.293a1 1 0 1 1 1.414 1.414L13.414 12l6.293 6.293a1 1 0 0 1-1.414 1.414L12 13.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L10.586 12 4.293 5.707a1 1 0 0 1 0-1.414Z"></path>`
+    closeIconSvg.insertAdjacentHTML('beforeend', iconPathHTML)
+
+    // modal 창 header
+    const modalHeader               = createNode('h6')
+    modalHeader.className           = 'm1oixje6 bordered sticky'
+    modalHeader.innerText           = '항목 삭제'
+    modalHeader.setAttribute('data-cy', 'modal-header')
+    appendTag(btnContainer, modalHeader)
+
+    // delete 안내문 및 delete 버튼
+    const confirmContainer          = createNode('div')
+    appendTag(btnContainer, confirmContainer)
+
+    const confirmTextContainer      = createNode('div')
+    confirmTextContainer.className  = 'mweydr9'
+    appendTag(confirmContainer, confirmTextContainer)
+
+    const confirmText               = createNode('p')
+    confirmText.innerText           = `이 항목을 삭제하겠습니까? 삭제한 항목은 복원할 수 없습니다.`
+    appendTag(confirmTextContainer, confirmText)
+
+    const deleteBtnContainer        = createNode('div')
+    deleteBtnContainer.className    = 'm11mcrga bordered sticky'
+    appendTag(btnContainer, deleteBtnContainer)
+
+    const deleteButton              = createNode('button')
+    deleteButton.className          = 'b18soqoe primary normal'
+    deleteButton.type               = 'submit'
+    deleteButton.innerText          = '삭제'
+    deleteButton.setAttribute('data-cy' ,'delete-confirm')
+    appendTag(deleteBtnContainer, deleteButton)
+
+    // Modal 창 닫기
+    closeBtn.addEventListener('click', () => {
+        closeModal()
+    })
+
+    // modal 창 삭제 버튼 클릭 시, 삭제 실행 및 modal 창 닫기 
+    deleteButton.addEventListener('click', () => {
+        
+        // 삭제 실행
+        deleteSite()
+
+        // Modal 창 닫기
+        closeModal()
+
+        // 항목 전체 다시 조회
+        window.location.reload()
+        
+    })
+
+}
+
+function openModal(deleteButton) {
+    /* 하단 툴바의 삭제 버튼 클릭으로 modal 창 open */
+    
+    deleteButton.addEventListener('click', () => {
+        const body              = getElement('body');
+        const modalOverlay      = getElement('.o1ohlj7h')
+
+        body.classList.add('modal-open')
+        modalOverlay.classList.add('animation-show');
+    })
+
+
+}   
+
+function closeModal() {
+    /* Modal 창 닫기 */
+
+    const body                  = getElement('body');
+    const modalOverlay          = getElement('.o1ohlj7h')
+        
+    modalOverlay.classList.remove('animation-show');
+    body.classList.remove('modal-open')
+}
+
+function deleteSite() {
+    /* DELETE http message를 보내는 함수 */
+
+    const site = getElement('.c18o9ext.grid.hiddenActions.noExcerpt.selected')
+    const csrftoken             = getCookie('csrftoken');
+    const data                  = {
+        method: 'DELETE',
+        headers: {
+            'content-type': 'application/json',
+            'X-CSRFToken' : csrftoken,  
+        },
+    }
+    
+    fetch(`/api/sites/${site.id}`, data)
+    .then(response => {
+        const status             = response.status
+        
+        if (status === 200) {
+            console.log('삭제 완료했습니다.')
+        } else if (status === 404) {
+            console.log('해당 항목이 존재하지 않습니다.')
+        } return response.json() 
+    })
+    .catch(error => console.log('Error:', error))
+}
+
+
+export {
+    makeModal,
+    openModal,
+}

--- a/templates/mylist/base.html
+++ b/templates/mylist/base.html
@@ -7,6 +7,8 @@
     <script type="module" src="{% static '/js/get-site-list.js' %}"></script>
     <script src="https://kit.fontawesome.com/c7083b595c.js" crossorigin="anonymous"></script>
     
+
+    <link rel="stylesheet" href="{% static '/css/modal.css' %}">
     <link rel="stylesheet" href="{% static '/css/mylist/base.css' %}">
     <link rel="stylesheet" href="{% static '/css/mylist/nav.css' %}">    
     <link rel="stylesheet" href="{% static '/css/mylist/header.css' %}">


### PR DESCRIPTION
## What about is this PR? 🔍
- api_patterns에 있는 api url을 수정했습니다. 
- 하단 툴바의 삭제 버튼을 통해서 모달 창을 띄우고, 모달 창을 통해 삭제하는 기능을 추가했습니다.


<br>

## Change Logic 📝

### before
- 이전 api url 형태는 'api/sites/`  로 이와 같았습니다.
- 각 site에 대한 삭제(DELETE) 기능이 없었습니다.

### after
- 로직 변경 후, url 맨 뒤에 있는 '/`를 각 api-url 에서 제거했습니다. 그 이유는 이 '/'가 있으면 다음 경로를 바라보고 있는 것이기 때문에, 예를 들어 sites 자체를 바라보는 게 아니어서 rest하지 못하기 때문입니다. 
- Pocket처럼 하단 툴바의 삭제 아이콘을 클릭하면 바로 삭제되는 게 아닌, 모달 창을 띄워서 재확인 후 진행하도록 했습니다.

<br>

## To Reviewers 👂
- feature-modal로 해야하는데, modal로 진행했었네요. 죄송합니다.
- RESTful API가 무엇인지 보다 더 이해하기 위해서, 지난 번 박지훈 멘토님이 말씀하신 RESTful API 에 대한 내용을 복습하시면 좋겠습니다.
- 리액트를 사용하지 않고 모달창을 띄워서 삭제를 구현할 경우, 각 항목의 태그에 각 항목을 구별하는 식별자를 직접 만들어야합니다. 리액트에서는 이를 자동적으로 식별하기 때문에 사용자가 직접 만들 필요가 없습니다. 하지만, 저희는 순수 자바스크립트로 하기 때문에 이를 직접 구현해야 합니다. 
- 식별자를 만들지 않고 각 post.id가 모달창까지 이어져서 모달창에서 삭제를 진행할 경우, 한 항목의 하단 툴바에서 클릭하여 진행한 것이지만 모든 항목이 삭제되는 문제가 발생합니다. 그래서 각 항목의 태그에 식별자를 만들어서 이 태그로 각 항목에 접근하여 삭제를 진행했습니다.


<br>

## Screenshot 📷
- 모달 창 오픈
<img width="1141" alt="Screen Shot 2022-11-19 at 9 49 02 PM" src="https://user-images.githubusercontent.com/78094972/202851684-58ccb468-67ea-4db1-883d-a2d10a856598.png">

- 삭제 실행 후 
<img width="1069" alt="Screen Shot 2022-11-19 at 9 49 15 PM" src="https://user-images.githubusercontent.com/78094972/202851702-fa73d202-89f4-4345-9540-2138a113d1c9.png">

