### PR TITLE
ADD: add bulktoolbar function and fix etc

### DIFF
--- a/pocket/decorator.py
+++ b/pocket/decorator.py
@@ -9,7 +9,7 @@ def scrap_decorator(func):
 
     @wraps(func)
     def exec_func(self, request) -> func:
-        # path 파라미터 -> request body 파라미터로 절달 변경
+        # path 파라미터 -> request body 파라미터로 전달 변경
         url: str = self.request.data.get('url')
 
         if access(scheme(slash(url)), header): 

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
-from rest_framework.generics import DestroyAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status

--- a/static/css/mylist/body.css
+++ b/static/css/mylist/body.css
@@ -3,7 +3,8 @@
     position: relative;
     border-radius: var(--size025);
     overflow: hidden;
-    padding-bottom: 1rem
+    padding-bottom: 1rem;
+    padding-top : 1rem;
 }
 
 .side-by-side .c97c5c {
@@ -463,7 +464,8 @@
 .c18o9ext.block .cardWrap,
 .c18o9ext.grid .cardWrap {
     display: block;
-    padding-bottom: 2.5rem
+    padding-bottom: 2.5rem;
+    cursor: pointer;
 }
 
 .c18o9ext.block.hiddenActions .actions a,
@@ -525,7 +527,8 @@
     .c18o9ext.block .cardWrap,
     .c18o9ext.grid .cardWrap {
         display: grid;
-        padding-bottom: 1.85rem
+        padding-bottom: 1.85rem;
+        cursor: pointer;
     }
 
     .c18o9ext.block .footer .actions,
@@ -1428,4 +1431,9 @@
 
 .fa-lg {
     vertical-align: -0.6em;
+}
+
+.item-bulk-select {
+    cursor: pointer;
+    padding-left: 85%;
 }

--- a/static/css/mylist/header.css
+++ b/static/css/mylist/header.css
@@ -2043,3 +2043,8 @@ a:hover .b1bq2cra {
 .off {
     display: none !important;
 }
+
+.item-bulk-select {
+    cursor: pointer;
+    padding-left: 85%;
+}

--- a/static/css/mylist/header.css
+++ b/static/css/mylist/header.css
@@ -2041,5 +2041,5 @@ a:hover .b1bq2cra {
 }
 
 .off {
-    display: none;
+    display: none !important;
 }

--- a/static/css/mylist/nav.css
+++ b/static/css/mylist/nav.css
@@ -1003,7 +1003,8 @@ a.button, button, input[type=button], input[type=reset], input[type=submit] {
     line-height: 110%;
     padding: .75rem;
     text-decoration: none;
-    white-space:nowrap
+    white-space:nowrap;
+    margin-right:1em;
 }
 
 a.button:hover, button:hover, input[type=button]:hover, input[type=reset]:hover, input[type=submit]:hover {

--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -116,6 +116,23 @@ function makeBottomToolbar(parentNode, post) {
  
      // bottom toolbar - delete
      makeDeleteInToolBar(itemActions, post)
+
+     let itemBulkContainer = createNode('div')
+     itemBulkContainer.className = 'item-bulk-select off'
+     appendTag(itemActionsContainer, itemBulkContainer)
+
+     let itemBulkIcon = createNode('span')
+     itemBulkIcon.className = 'i1qqph0t icon'
+     appendTag(itemBulkContainer, itemBulkIcon)
+
+     let itemBulkIconSvgHtml = `<svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class='select-icon-svg'></svg>`
+     itemBulkIcon.insertAdjacentHTML('beforeend', itemBulkIconSvgHtml)   
+     
+     let itemBulkIconSvg = itemBulkIcon.querySelector('.select-icon-svg')
+
+     let itemBulkIconPathHtml = `<path fill-rule="evenodd" clip-rule="evenodd" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 2c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Z"></path>`
+     itemBulkIconSvg.insertAdjacentHTML('beforeend', itemBulkIconPathHtml)   
+     
 }
 
 function changeFavoriteValue(favoriteButton, post) {

--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -117,6 +117,7 @@ function makeBottomToolbar(parentNode, post) {
      // bottom toolbar - delete
      makeDeleteInToolBar(itemActions, post)
 
+     // toolbar bulk 선택 시 활성화 icon
      let itemBulkContainer = createNode('div')
      itemBulkContainer.className = 'item-bulk-select off'
      appendTag(itemActionsContainer, itemBulkContainer)
@@ -130,9 +131,12 @@ function makeBottomToolbar(parentNode, post) {
      
      let itemBulkIconSvg = itemBulkIcon.querySelector('.select-icon-svg')
 
-     let itemBulkIconPathHtml = `<path fill-rule="evenodd" clip-rule="evenodd" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 2c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Z"></path>`
-     itemBulkIconSvg.insertAdjacentHTML('beforeend', itemBulkIconPathHtml)   
+     let itemBulkIconPathHtml = `<path fill-rule="evenodd" clip-rule="evenodd" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 2c6.075 0 11-4.925 11-11S18.075 1 12 1 1 5.925 1 12s4.925 11 11 11Z" class='select-dot-empty'></path>`
+     itemBulkIconSvg.insertAdjacentHTML('beforeend', itemBulkIconPathHtml)
      
+     let itemBulkIconDotPathHtml = `<path fill-rule="evenodd" clip-rule="evenodd" d="M16.707 9.293a1 1 0 0 1 0 1.414l-5 5a1 1 0 0 1-1.414 0l-3-3a1 1 0 1 1 1.414-1.414L11 13.586l4.293-4.293a1 1 0 0 1 1.414 0Z"  class='select-dot-choice off'></path>`
+     itemBulkIconSvg.insertAdjacentHTML('beforeend', itemBulkIconDotPathHtml)
+
 }
 
 function changeFavoriteValue(favoriteButton, post) {

--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -90,7 +90,7 @@ function makeDeleteInToolBar(parentNode, site) {
     deleteButton.addEventListener('click', () => {
         const article = document.getElementById(`${site.id}`)
         article.classList.add('selected')
-        openModal(deleteButton)
+        openModal()
     })
 
 }

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -77,6 +77,23 @@ function getCookie(name) {
     return cookieValue;
 }
 
+function setFechData(method, body){
+    /* bulk 삭제 이벤트 */
+
+    let csrftoken   = getCookie('csrftoken');
+
+    const data = {
+        method: method,
+        headers: {
+            'content-type': 'application/json',
+            'X-CSRFToken' : csrftoken,        
+        },
+        body: JSON.stringify(body)
+    }
+
+    return data
+}
+
 export {
     getElement,
     getElements,
@@ -87,4 +104,5 @@ export {
     appendTag,
     removeAllNode,
     getCookie, 
+    setFechData,
 };

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -14,6 +14,12 @@ function renderItem(post) {
     article.onclick             = selectBulkIcon
     appendTag(root, article)
 
+    const postId                = createNode('input')
+    postId.className            = 'site-id'
+    postId.value                = post.id
+    postId.type                 = 'hidden'
+    appendTag(article, postId)
+
     const selectedBack          = createNode('div')
     selectedBack.className      = 'selectedBack'
     appendTag(article, selectedBack)
@@ -75,11 +81,13 @@ function selectBulkIcon(){
         choiceIcon.classList.toggle('off')
         
         // 선택 벌크 카운팅
-        countSelectedBuik()
+        countSelectedBulk()
     }
 }
 
-function countSelectedBuik(){
+function countSelectedBulk(){
+    /* 사이트 항목 선택 시 선택한 개수 toolbar에 표시하는 카운팅 함수 */
+
     const selected_articles = []
     const articles = getElements('.c18o9ext')
 

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -3,9 +3,10 @@ import { makeBottomToolbar } from './bottom-toolbar.js';
 import { makeModal } from './modal.js';
 import { apiURL } from './api-url.js';
 
-const root          = document.getElementById("root")
-const url           = window.location.pathname.split('/');
-const apiUrlKey     = url.filter((element) => element != "").pop();
+const root            = document.getElementById("root")
+const url             = window.location.pathname.split('/');
+const apiUrlKey       = url.filter((element) => element != "").pop();
+let selected_articles = []
 
 function renderItem(site) {
     /* 각 item의 tag를 rendering 하는 함수 */
@@ -18,7 +19,7 @@ function renderItem(site) {
 
     const postId                = createNode('input')
     postId.className            = 'site-id'
-    postId.value                = post.id
+    postId.value                = site.id
     postId.type                 = 'hidden'
     appendTag(article, postId)
 
@@ -76,6 +77,7 @@ function selectBulkIcon(){
 
     const headerToolbar = getElement('.n27eiag')
 
+    // toolbar가 bulk상태인지 확인 후 선택 이벤트 부여
     if (headerToolbar.classList.contains('bulk')) {
         this.classList.toggle('selected')
     
@@ -90,14 +92,15 @@ function selectBulkIcon(){
 function countSelectedBulk(){
     /* 사이트 항목 선택 시 선택한 개수 toolbar에 표시하는 카운팅 함수 */
 
-    const selected_articles = []
     const articles = getElements('.c18o9ext')
+    selected_articles = new Array()
 
     articles.forEach(element => {
-        if(element.classList.contains('selected')){
-            selected_articles.push(element)
-        }
-    })
+        
+        if(element.classList.contains('selected'))
+            selected_articles.push(element.querySelector('.site-id').value)
+        
+        })
 
     const selectedSite = getElement('.selected-site')
     selectedSite.textContent = selected_articles.length == 0 ? '항목선택' : `${selected_articles.length}개 항목`
@@ -145,14 +148,15 @@ function makeActive() {
    
   }
 
-function getSiteList(word='') {
+// 비동기로 조회 되면 앞의 생성되는 DOM을 읽지 못하므로 동기처리
+async function getSiteList(word='') {
     /* 각 탭에 해당되는 모든 항목들을 조회하여 함수 */
     
     // 선택한 탭 활성화하기  
     makeActive()
 
     // 해당되는 항목들 조회하기  
-    fetch(`${apiURL[apiUrlKey]}?word=${word}`)
+    await fetch(`${apiURL[apiUrlKey]}?word=${word}`)
         .then(response => response.json())
         .then(data => {
             mapPosts(data)
@@ -166,5 +170,6 @@ getSiteList()
 makeModal()
 
 export {
-    getSiteList
+    getSiteList,
+    selected_articles,
 };

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -1,4 +1,4 @@
-import {createNode, appendTag, getElement, removeAllNode} from './common.js';
+import {createNode, appendTag, getElement, getElements, removeAllNode} from './common.js';
 import { makeBottomToolbar } from './bottom-toolbar.js';
 import { apiURL } from './api-url.js';
 
@@ -11,7 +11,12 @@ function renderItem(post) {
 
     const article               = createNode('article')
     article.className           = 'c18o9ext grid hiddenActions noExcerpt'
+    article.onclick             = selectBulkIcon
     appendTag(root, article)
+
+    const selectedBack          = createNode('div')
+    selectedBack.className      = 'selectedBack'
+    appendTag(article, selectedBack)
 
     const item                  = createNode('div')
     item.className              = 'cardWrap'
@@ -56,6 +61,36 @@ function renderItem(post) {
     // 각 항목(item)의 하단 툴바
     makeBottomToolbar(article, post)
    
+}
+
+function selectBulkIcon(){
+    /* bulk toolbar 활성화 시 사이트 항목 선택 이벤트  */
+
+    const headerToolbar = getElement('.n27eiag')
+
+    if (headerToolbar.classList.contains('bulk')) {
+        this.classList.toggle('selected')
+    
+        let choiceIcon = this.querySelector('.select-dot-choice')
+        choiceIcon.classList.toggle('off')
+        
+        // 선택 벌크 카운팅
+        countSelectedBuik()
+    }
+}
+
+function countSelectedBuik(){
+    const selected_articles = []
+    const articles = getElements('.c18o9ext')
+
+    articles.forEach(element => {
+        if(element.classList.contains('selected')){
+            selected_articles.push(element)
+        }
+    })
+
+    const selectedSite = getElement('.selected-site')
+    selectedSite.textContent = selected_articles.length == 0 ? '항목선택' : `${selected_articles.length}개 항목`
 }
 
 function mapPosts(data) {

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,4 +1,4 @@
-import { createNode, appendTag, getElement, getCookie } from './common.js';
+import { createNode, appendTag, getElement, getCookie, getElements } from './common.js';
 
 function makeModal() {
     /* modal 창 만들기 */
@@ -12,7 +12,7 @@ function makeModal() {
     appendTag(next, modalOverlay)
 
     const modalContent              = createNode('div')
-    modalContent.className          = "ReactModal__Content ReactModal__Content--after-open m1gbisw7 animation-base animation-show"
+    modalContent.className          = "ReactModal__Content ReactModal__Content--after-open m1gbisw7 animation-base animation-show off"
     modalContent.tabindex           = '-1'
     modalContent.role               = 'dialog'
     modalContent.setAttribute('aria-label', '항목 삭제')
@@ -90,28 +90,32 @@ function makeModal() {
 
 }
 
-function openModal(deleteButton) {
+function openModal() {
     /* 하단 툴바의 삭제 버튼 클릭으로 modal 창 open */
-    
-    deleteButton.addEventListener('click', () => {
-        const body              = getElement('body');
-        const modalOverlay      = getElement('.o1ohlj7h')
+    const body              = getElement('body');
+    const modalOverlay      = getElement('.o1ohlj7h')
+    const hidModal          = getElement('.m1gbisw7')
 
-        body.classList.add('modal-open')
-        modalOverlay.classList.add('animation-show');
-    })
-
-
+    modalOverlay.classList.add('animation-show');
+    body.classList.add('modal-open')
+    hidModal.classList.toggle('off')
 }   
 
 function closeModal() {
     /* Modal 창 닫기 */
 
     const body                  = getElement('body');
+    const articles              = getElements('article')
     const modalOverlay          = getElement('.o1ohlj7h')
-        
+    const hidModal              = getElement('.m1gbisw7')
+
     modalOverlay.classList.remove('animation-show');
     body.classList.remove('modal-open')
+    hidModal.classList.toggle('off')       
+
+    articles.forEach((element) => {
+        element.classList.remove('selected')
+    })
 }
 
 function deleteSite() {

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -198,7 +198,7 @@ function makeBulkTopToolBar() {
     appendTag(bulkContainer, bulkAction)
     
     const tagButton                     = createNode('button')
-    tagButton.className                 = 'b1vi9mhm t1221eea pzhe358'
+    tagButton.className                 = 'b1vi9mhm t1221eea pzhe358 bulk-tag'
 
     tagButton.setAttribute('aria-label', '꼬리표')
     tagButton.setAttribute('data-cy', 'bulk-tag')
@@ -219,7 +219,7 @@ function makeBulkTopToolBar() {
     tagIconSvg.insertAdjacentHTML('beforeend', tagIconPathHtml)
 
     const favoriteButton                = createNode('button')
-    favoriteButton.className            = 'b1vi9mhm t1221eea pzhe358'
+    favoriteButton.className            = 'b1vi9mhm t1221eea pzhe358 bulk-favorite'
 
     favoriteButton.setAttribute('aria-label', '가장 좋아하는')
     favoriteButton.setAttribute('data-cy', 'bulk-favorite')
@@ -238,7 +238,7 @@ function makeBulkTopToolBar() {
     favoriteIconSvg.insertAdjacentHTML('beforeend', favoriteIconPathHtml)
 
     const categoryButton                = createNode('button')
-    categoryButton.className            = 'b1vi9mhm t1221eea pzhe358'
+    categoryButton.className            = 'b1vi9mhm t1221eea pzhe358 bulk-category'
 
     categoryButton.setAttribute('aria-label', '카테고리')
     categoryButton.setAttribute('data-cy', 'bulk-category')
@@ -257,7 +257,7 @@ function makeBulkTopToolBar() {
     categoryIconSvg.insertAdjacentHTML('beforeend', categoryIconPathHtml)
 
     const deleteButton                  = createNode('button')
-    deleteButton.className              = 'b1vi9mhm t1221eea pzhe358'
+    deleteButton.className              = 'b1vi9mhm t1221eea pzhe358 bulk-delete'
     deleteButton.setAttribute('aria-label', '삭제')
     deleteButton.setAttribute('data-cy', 'bulk-delete')
     deleteButton.setAttribute('data-tooltip', 'Delete')
@@ -338,6 +338,9 @@ function makeBulkTopToolBar() {
 
     // bulk 버튼 클릭 시 벌크 선택 활성화
     activeSelectBulk()
+
+    // bulk 내 태그, 즐겨찾기, 카테고리, 삭제 버튼 이베트
+    bulkButtonEventSet()
 }
 
 function activeSelectBulk() {
@@ -373,7 +376,7 @@ function changeSelectBulk() {
 
     // 벌크 활성화 상태 체크
     headerToolbar.classList.toggle('bulk')
-
+    
     bottomToolbarConatiner.forEach(element => {
         element.classList.toggle('bulkEdit')
 
@@ -473,3 +476,26 @@ btnBulk.addEventListener('click', () => {
 
     makeBulkTopToolBar()
 })
+
+function bulkButtonEventSet(){
+    const btnBulkTag       = getElement('.bulk-tag')
+    const btnBulkFavorite  = getElement('.bulk-favorite')
+    const btnBulkCategory  = getElement('.bulk-category')
+    const btnBulkDelete    = getElement('.bulk-delete')
+
+    btnBulkTag.addEventListener('click', () => {
+        alert('벌크 태그')
+    })
+    
+    btnBulkFavorite.addEventListener('click', () => {
+        alert('벌크 즐겨찾기')
+    })
+    
+    btnBulkCategory.addEventListener('click', () => {
+        alert('벌크 카테고리')
+    })
+    
+    btnBulkDelete.addEventListener('click', () => {
+        alert('벌크 삭제')
+    })
+}

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -286,7 +286,7 @@ function makeBulkTopToolBar() {
     appendTag(toolbarActionLabl, mobileItemSelect)
     
     const mobileItemSelectFont          = createNode('font')
-    mobileItemSelectFont.style          = 'vertical-align: inherit;'
+    mobileItemSelectFont.style          = 'vertical-align: inherit; display:block; min-width:100px;'
     mobileItemSelectFont.textContent    = '항목선택'
     appendTag(mobileItemSelect, mobileItemSelectFont)
     
@@ -334,19 +334,49 @@ function makeBulkTopToolBar() {
     appendTag(cancleTextSpan, cancleTextFont)
     
     toolbarCancelBtn()
+
+    // bulk 버튼 클릭 시 벌크 선택 활성화
+    activeSelectBulk()
+}
+
+function activeSelectBulk() {
+    /* toolbar bulk 활성화시 사이트 항목 선택 버튼 활성화 */
+    
+    // toolbar 활성화 시 벌크 선택 toggle 처리(활성화)
+    changeSelectBulk()
 }
 
 function toolbarCancelBtn () {
     /* toolbar 닫기 클릭 이벤트 */
-
-    const btnCancels                    = getElements('.toolbar-cancel');
-    const toolbarContainer              = getElement('.toolbar-container');
+    
+    const btnCancels = getElements('.toolbar-cancel');
+    const toolbarContainer = getElement('.toolbar-container');
 
     btnCancels.forEach((element) => {
         element.addEventListener('click', () => {
+            // 취소 버튼 클릭 시 툴바 컨테이너 지운 후 기본 mane 활성화
             makeElementOn(menuContainer, toolContainer, profileContainer)
             removeElement(toolbarContainer)
+            
+            // 취소 버튼 클릭 시 벌크 선택 toggle 처리(비확성화)      
+            changeSelectBulk()
         })
+    }) 
+}
+
+function changeSelectBulk() {
+    /* 벌크 선택 유무를 확인 후 change 함수 */
+    
+    const bottomToolbarConatiner = getElements('.i18uycg6')
+
+    bottomToolbarConatiner.forEach(element => {
+        element.classList.toggle('bulkEdit')
+
+        let bottomToolbar = element.querySelector('.item-actions')
+        let bulkToolbar = element.querySelector('.item-bulk-select')
+
+        bottomToolbar.classList.toggle('off')
+        bulkToolbar.classList.toggle('off')
     })
 }
 
@@ -407,13 +437,13 @@ function searchSitebyToolbar () {
     })
 }
 
-const headerContainer   = getElement('.global-nav-container > .n27eiag');
-const toolContainer     = getElement('.toolbar-wrap');
-const profileContainer  = getElement('.profile-wrap');
-const menuContainer     = getElement('.menu-wrap');
-const btnSearch         = getElement('#search');
-const btnSave           = getElement('#save');
-const btnBulk           = getElement('#bulk');
+const headerContainer  = getElement('.global-nav-container > .n27eiag');
+const toolContainer    = getElement('.toolbar-wrap');
+const profileContainer = getElement('.profile-wrap');
+const menuContainer    = getElement('.menu-wrap');
+const btnSearch        = getElement('#search');
+const btnSave          = getElement('#save');
+const btnBulk          = getElement('#bulk');
 
 btnSearch.addEventListener('click', () => {
     /* 검색 toolbar 클릭 이벤트 */

--- a/static/js/toolbar.js
+++ b/static/js/toolbar.js
@@ -286,6 +286,7 @@ function makeBulkTopToolBar() {
     appendTag(toolbarActionLabl, mobileItemSelect)
     
     const mobileItemSelectFont          = createNode('font')
+    mobileItemSelectFont.className      = 'selected-site'
     mobileItemSelectFont.style          = 'vertical-align: inherit; display:block; min-width:100px;'
     mobileItemSelectFont.textContent    = '항목선택'
     appendTag(mobileItemSelect, mobileItemSelectFont)
@@ -366,8 +367,12 @@ function toolbarCancelBtn () {
 
 function changeSelectBulk() {
     /* 벌크 선택 유무를 확인 후 change 함수 */
-    
+
+    const headerToolbar = getElement('.n27eiag')
     const bottomToolbarConatiner = getElements('.i18uycg6')
+
+    // 벌크 활성화 상태 체크
+    headerToolbar.classList.toggle('bulk')
 
     bottomToolbarConatiner.forEach(element => {
         element.classList.toggle('bulkEdit')

--- a/templates/mylist/base.html
+++ b/templates/mylist/base.html
@@ -177,5 +177,3 @@
 
 <!-- FOOTER -->
 {% include 'mylist/footer.html' %}
-
-</div>


### PR DESCRIPTION
## What about is this PR? 🔍
- decorator.py 주석 오타 수정
- Toolbar Delete 기능 SiteBulkAPIView 추가 
- 벌크 선택 시 사이트 항목 선택 check 이벤트 적용
- 불필요한 가변 매개변수, 키워드 매개변수 제거
- parsing 작업 시 article 구분 조건 추가
- 삭제 버튼을 두번 클릭으로 모달창 노출하는 코드 수정
- 공통함수 setFetchData 함수 추가 및 기타 css 추가 수정


<br>

## Change Logic 📝

### before
- decorator.py 절달로 잘못된 주석 표기
- views.py > SiteDetailAPIView 사용되지 않은 args, kwards값을 매개변수로 담고 있음
- views.py > ParseAPIView pasing 작업 시 사이트에 대한 type 구분 'article'로만 구분
- 조회된 사이트 항목에 마우스 hover 일반 마우스 포인터 표시
- fetch 함수 선언 할때 마다 data값을 중복되게 선언 

### after
- decorator.py 전달로 잘못된 주석 수정
- views.py > SiteDetailAPIView 사용되지 않은 args, kwards값 제거
- Toolbar Delete하는 SiteBulkAPIView 추가
    - pk인자를 배열값으로 받아 반복문을 통해 해당 데이터들을 삭제하는 로직 추가
- views.py > ParseAPIView pasing 작업시 사이트에 대한 type 구분 'website' 추가
- 조회된 사이트 항목에 마우스 hover시 cusor: pointer css 추가
- .off css 항목에 !important 속성을 주어 강제성 추가
    - !important속성을 추가하지 않으면 다른 강제성 있는 css가 .off를 무효화 시킴
- bottom-toolbar.js 하단 bulk 선택 DOM 생성 로직 추가
- bottom-toolbar.js openModal 호출 시 보내던 매개변수 제거
- fetch 함수 선언 할때 마다 중복되게 선언되고 있던 셋팅 방법을 공통함수를 만들어 필요한 인자만 받아 셋팅할 수 있게 추가
- 각 article 선택 시 마다 선택 표시 이벤트 추가
- getSiteList함수 사용 시 앞서 생성된 DOM을 읽지 못하는 현상을 처리하기 위해 async, await 추가
- 사이트 항복 삭제 버튼 클릭 시 중복된 클릭 이벤트 부여 수정

<br>

## To Reviewers 👂
- fetch 함수 사용시 data 셋팅은 아래 방법으로 진행해 주세요
```python
const data = setFechData('POST', {
                url: url,
                user: 'User Id' ,
            })
```

<br>

## Screenshot 📷
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/103980058/203223197-b192dc33-6d18-4549-9cb2-4aae5aa1da98.png">

<br>