### PR TITLE
Add detail screen and add-ons

### DIFF
--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -18,6 +18,7 @@ from pocket.views import (
     PwdHelpView, 
     PremiumView,
     PaymentView,
+    DetailView
 
 )
 
@@ -42,7 +43,10 @@ urlpatterns = [
     path('mylist/', mylist_view, name='mylist'), 
     path('mylist/favorites/', mylist_view, name='favorites'), 
     path('mylist/articles/', mylist_view, name='articles'), 
-    path('mylist/videos/', mylist_view, name='videos'), 
+    path('mylist/videos/', mylist_view, name='videos'),
+
+    # detail
+    path('mylist/detail/', DetailView.as_view(), name='detail'), 
 
     # payment
     path('premium/', PremiumView.as_view(), name='premium'),

--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -18,7 +18,7 @@ from pocket.views import (
     PwdHelpView, 
     PremiumView,
     PaymentView,
-    DetailView
+    site_detail_view
 
 )
 
@@ -46,7 +46,7 @@ urlpatterns = [
     path('mylist/videos/', mylist_view, name='videos'),
 
     # detail
-    path('mylist/detail/', DetailView.as_view(), name='detail'), 
+    path('mylist/detail/<int:pk>/', site_detail_view, name='site_detail_view'), 
 
     # payment
     path('premium/', PremiumView.as_view(), name='premium'),

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -17,20 +17,20 @@ import requests
 
 
 def site_detail_view(request, pk):
-
     """
     mylist/base.html에 모든 항목들 리스트를 전달하는 함수
     """
+
     if request.method == 'GET': 
 
         return render(request, 'mylist/detail/detail.html', {'pk' : pk})
 
 
 def mylist_view(request):
-
     """
     mylist/base.html에 모든 항목들 리스트를 전달하는 함수
     """
+    
     if request.method == 'GET': 
 
         return render(request, 'mylist/base.html')
@@ -255,17 +255,6 @@ class VideoAPIView(APIView):
         serializer = SiteSerializer(list_qs, many=True)
 
         return Response(serializer.data)
-
-# class DetailView(TemplateView):
-#     """
-#     detail 상세화면 템플릿 뷰
-#     """
-#     template_name = 'mylist/detail/detail.html'
-
-#     def get(self, request, *args, **kwargs):
-#         response = super(DetailView, self).get(self, request, *args, **kwargs)
-#         return response
-
 
         
 class ParseAPIView(APIView):

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -16,6 +16,17 @@ import requests
 
 # template view
 
+
+def site_detail_view(request, pk):
+
+    """
+    mylist/base.html에 모든 항목들 리스트를 전달하는 함수
+    """
+    if request.method == 'GET': 
+
+        return render(request, 'mylist/detail/detail.html')
+
+
 def mylist_view(request):
 
     """
@@ -177,15 +188,15 @@ class VideoAPIView(APIView):
 
         return Response(serializer.data)
 
-class DetailView(TemplateView):
-    """
-    detail 상세화면 템플릿 뷰
-    """
-    template_name = 'mylist/detail/detail.html'
+# class DetailView(TemplateView):
+#     """
+#     detail 상세화면 템플릿 뷰
+#     """
+#     template_name = 'mylist/detail/detail.html'
 
-    def get(self, request, *args, **kwargs):
-        response = super(DetailView, self).get(self, *args, **kwargs)
-        return response
+#     def get(self, request, *args, **kwargs):
+#         response = super(DetailView, self).get(self, request, *args, **kwargs)
+#         return response
 
 
         

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -177,6 +177,17 @@ class VideoAPIView(APIView):
 
         return Response(serializer.data)
 
+class DetailView(TemplateView):
+    """
+    detail 상세화면 템플릿 뷰
+    """
+    template_name = 'mylist/detail/detail.html'
+
+    def get(self, request, *args, **kwargs):
+        response = super(DetailView, self).get(self, *args, **kwargs)
+        return response
+
+
         
 class ParseAPIView(APIView):
     @scrap_decorator

--- a/static/css/mylist/detail/detail.css
+++ b/static/css/mylist/detail/detail.css
@@ -1,0 +1,30 @@
+.header {
+    width: 100%;
+    height: 64px;
+    border-bottom: 1px solid #d9d9d9;
+    box-shadow: 0 2px 12px rgba(0,0,0,.08);
+}
+
+.header-wrapper {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 40px;
+}
+
+
+.center-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 300px;
+}
+
+.header-svg {
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+}
+

--- a/static/css/mylist/detail/reset.css
+++ b/static/css/mylist/detail/reset.css
@@ -1,0 +1,207 @@
+/* BROWSER RESETS --------------------------------------------- */
+*,:after,:before{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);font-family:sans-serif;line-height:1.15}
+article,aside,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+body{background-color:#fff;color:#212529;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;font-size:1rem;font-weight:400;line-height:1.5;margin:0;text-align:left}
+[tabindex="-1"]:focus{outline:0!important}
+hr{box-sizing:content-box;height:0;overflow:visible}
+h1,h2,h3,h4,h5,h6{margin-bottom:.5rem;margin-top:0}
+p{margin-bottom:1rem;margin-top:0}
+abbr[data-original-title],abbr[title]{border-bottom:0;cursor:help;text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}
+address{font-style:normal;line-height:inherit}
+address,dl,ol,ul{margin-bottom:1rem}
+dl,ol,ul{margin-top:0}
+ol ol,ol ul,ul ol,ul ul{margin-bottom:0}
+dt{font-weight:700}
+dd{margin-bottom:.5rem;margin-left:0}
+blockquote{margin:0 0 1rem}
+b,strong{font-weight:bolder}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sub{bottom:-.25em}
+sup{top:-.5em}
+a{background-color:transparent;text-decoration:none}
+a,a:hover{color:inherit}
+a:hover{text-decoration:underline}
+a:not([href]):not([tabindex]),a:not([href]):not([tabindex]):focus,a:not([href]):not([tabindex]):hover{color:inherit;text-decoration:none}
+a:not([href]):not([tabindex]):focus{outline:0}
+code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-size:1em}
+pre{margin-bottom:1rem;margin-top:0;overflow:auto}
+figure{margin:0 0 1rem}
+img{border-style:none}
+img,svg{vertical-align:middle}
+svg{overflow:hidden}
+table{border-collapse:collapse}
+caption{caption-side:bottom;color:#6c757d;padding-bottom:.75rem;padding-top:.75rem;text-align:left}
+th{text-align:inherit}
+label{display:inline-block;margin-bottom:.5rem}
+button{border-radius:0}
+button:focus{outline:1px dotted;outline:5px auto -webkit-focus-ring-color}
+button,input,optgroup,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit;margin:0}
+button,input{overflow:visible}
+button,select{text-transform:none}
+select{word-wrap:normal}
+[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}
+[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}
+[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}
+input[type=checkbox],input[type=radio]{box-sizing:border-box;padding:0}
+input[type=date],input[type=datetime-local],input[type=month],input[type=time]{-webkit-appearance:listbox}
+textarea{overflow:auto;resize:vertical}
+fieldset{border:0;margin:0;min-width:0;padding:0}
+legend{color:inherit;display:block;font-size:1.5rem;line-height:inherit;margin-bottom:.5rem;max-width:100%;padding:0;white-space:normal;width:100%}
+progress{vertical-align:baseline}
+[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}
+[type=search]{-webkit-appearance:none;outline-offset:-2px}
+[type=search]::-webkit-search-decoration{-webkit-appearance:none}
+::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}
+output{display:inline-block}
+summary{cursor:pointer;display:list-item}
+template{display:none}
+[hidden]{display:none!important}
+/* STYLE VARIABLES  --------------------------------------------- */
+.colormode-light{--color-canvas:#fff;--color-textPrimary:#1a1a1a;--color-textSecondary:#666;--color-textTertiary:#8c8c8c;--color-textLinkHover:#008078;--color-textLinkPressed:#004d48;--color-textAccent:#3668ff;--color-actionPrimary:#008078;--color-actionPrimaryHover:#004d48;--color-actionPrimarySubdued:#e8f7f6;--color-actionPrimaryText:#fff;--color-actionSecondary:#1a1a1a;--color-actionSecondaryHover:#1a1a1a;--color-actionSecondaryHoverText:#f2f2f2;--color-actionSecondaryText:#1a1a1a;--color-actionBrand:#ef4056;--color-actionBrandHover:#901424;--color-actionBrandSubdued:#fdf2f5;--color-actionBrandText:#fff;--color-actionFocus:#009990;--color-formFieldFocusLabel:#008078;--color-formFieldTextPrimary:#1a1a1a;--color-formFieldTextSecondary:#666;--color-formFieldBorder:#8c8c8c;--color-formFieldBorderHover:#333;--color-error:#b24000;--color-toggleOff:#737373;--color-toggleOffHover:#404040;--color-popoverCanvas:#fff;--color-popoverBorder:#d9d9d9;--color-menuItemHover:#008078;--color-menuItemHoverText:#fff;--color-menuItemActive:#004d48;--color-navCurrentTab:#e0f0ef;--color-navCurrentTabText:#008078;--color-tooltipCanvas:#1a1a1a;--color-tooltipText:#f2f2f2;--color-drawerCanvas:#fff;--color-dividerPrimary:#333;--color-dividerSecondary:#8c8c8c;--color-dividerTertiary:#d9d9d9;--color-calloutBackgroundPrimary:#e8f7f6;--color-calloutBackgroundSecondary:#fdf2f5;--color-calloutAccent:#1a1a1a;--color-checkboxLabel:#404040;--color-checkboxBorder:#d9d9d9;--color-checkboxBackground:#fff;--color-checkboxInputBorder:#d9d9d9;--color-checkboxInputBackground:#fff;--color-checkboxHighlight:#009990;--color-checkboxLabelSelected:#008078;--color-checkboxBorderSelected:#008078;--color-checkboxBackgroundSelected:#e8f7f6;--color-checkboxInputBorderSelected:#008078;--color-checkboxInputBackgroundSelected:#008078}
+.colormode-dark{--color-canvas:#1a1a1a;--color-textPrimary:#f2f2f2;--color-textSecondary:#8c8c8c;--color-textTertiary:#737373;--color-textLinkHover:#00a69c;--color-textLinkPressed:#00d9cc;--color-textAccent:#95d2ff;--color-actionPrimary:#008078;--color-actionPrimaryHover:#004d48;--color-actionPrimarySubdued:#00403c;--color-actionPrimaryText:#fff;--color-actionSecondary:#f2f2f2;--color-actionSecondaryHover:#f2f2f2;--color-actionSecondaryHoverText:#1a1a1a;--color-actionSecondaryText:#f2f2f2;--color-actionBrand:#ef4056;--color-actionBrandHover:#901424;--color-actionBrandSubdued:#6c000e;--color-actionBrandText:#fff;--color-actionFocus:#00ccc0;--color-formFieldFocusLabel:#00a69c;--color-formFieldTextPrimary:#f2f2f2;--color-formFieldTextSecondary:#8c8c8c;--color-formFieldBorder:#737373;--color-formFieldBorderHover:#ccc;--color-error:#e55300;--color-toggleOff:#737373;--color-toggleOffHover:#404040;--color-popoverCanvas:#333;--color-popoverBorder:#595959;--color-menuItemHover:#008078;--color-menuItemHoverText:#fff;--color-menuItemActive:#004d48;--color-navCurrentTab:#274f4c;--color-navCurrentTabText:#00ccc0;--color-tooltipCanvas:#f2f2f2;--color-tooltipText:#1a1a1a;--color-drawerCanvas:#333;--color-dividerPrimary:#ccc;--color-dividerSecondary:#737373;--color-dividerTertiary:#404040;--color-calloutBackgroundPrimary:#004d48;--color-calloutBackgroundSecondary:#333;--color-calloutAccent:#00ccc0;--color-checkboxLabel:#fff;--color-checkboxBorder:#8c8c8c;--color-checkboxBackground:#1a1a1a;--color-checkboxInputBorder:#8c8c8c;--color-checkboxInputBackground:#1a1a1a;--color-checkboxHighlight:#009990;--color-checkboxLabelSelected:#e8f7f6;--color-checkboxBorderSelected:#e8f7f6;--color-checkboxBackgroundSelected:#008078;--color-checkboxInputBorderSelected:#fff;--color-checkboxInputBackgroundSelected:#fff}
+.colormode-sepia{--color-canvas:#f5eddd;--color-textPrimary:#191917;--color-textSecondary:#66635c;--color-textTertiary:#8c877e;--color-textLinkHover:#00736c;--color-textLinkPressed:#00403c;--color-textAccent:#1649ac;--color-actionPrimary:#00736c;--color-actionPrimaryHover:#00403c;--color-actionPrimarySubdued:#e8f7f6;--color-actionPrimaryText:#fff;--color-actionSecondary:#191917;--color-actionSecondaryHover:#191917;--color-actionSecondaryHoverText:#fffcf7;--color-actionSecondaryText:#191917;--color-actionBrand:#ef4056;--color-actionBrandHover:#901424;--color-actionBrandSubdued:#fdf2f5;--color-actionBrandText:#fff;--color-actionFocus:#009990;--color-formFieldFocusLabel:#00736c;--color-formFieldTextPrimary:#191917;--color-formFieldTextSecondary:#66635c;--color-formFieldBorder:#8c877e;--color-formFieldBorderHover:#33312e;--color-error:#b24000;--color-toggleOff:#66635c;--color-toggleOffHover:#403e3a;--color-popoverCanvas:#f5eddd;--color-popoverBorder:#ccc5b8;--color-menuItemHover:#00736c;--color-menuItemHoverText:#fffcf7;--color-menuItemActive:#00403c;--color-navCurrentTab:#d8decf;--color-navCurrentTabText:#00736c;--color-tooltipCanvas:#191917;--color-tooltipText:#f2f2f2;--color-drawerCanvas:#f5eddd;--color-dividerPrimary:#33312e;--color-dividerSecondary:#8c877e;--color-dividerTertiary:#ccc5b8;--color-calloutBackgroundPrimary:#e8f7f6;--color-calloutBackgroundSecondary:#fdf2f5;--color-calloutAccent:#1a1a1a;--color-checkboxLabel:#404040;--color-checkboxBorder:#d9d9d9;--color-checkboxBackground:#f5eddd;--color-checkboxInputBorder:#8c8c8c;--color-checkboxInputBackground:#f5eddd;--color-checkboxHighlight:#009990;--color-checkboxLabelSelected:#008078;--color-checkboxBorderSelected:#008078;--color-checkboxBackgroundSelected:#e8f7f6;--color-checkboxInputBorderSelected:#008078;--color-checkboxInputBackgroundSelected:#008078}
+:root{--color-grey10:#1a1a1a;--color-grey20:#333;--color-grey25:#404040;--color-grey30:#4d4d4d;--color-grey35:#595959;--color-grey40:#666;--color-grey45:#737373;--color-grey55:#8c8c8c;--color-grey65:#a6a6a6;--color-grey80:#ccc;--color-grey85:#d9d9d9;--color-grey95:#f2f2f2;--color-white100:#fff;--color-sepia10:#191917;--color-sepia20:#33312e;--color-sepia25:#403e3a;--color-sepia40:#66635c;--color-sepia45:#736f68;--color-sepia55:#8c877e;--color-sepia65:#a6a095;--color-sepia80:#ccc5b8;--color-sepia90:#e5decf;--color-sepia96:#f5eddd;--color-sepia100:#fff7e6;--color-cream100:#fffcf7;--color-teal25:#00403c;--color-teal30:#004d48;--color-teal45:#00736c;--color-teal50:#008078;--color-teal60:#009990;--color-teal65:#00a69c;--color-teal70:#00b2a8;--color-teal75:#00bfb4;--color-teal80:#00ccc0;--color-teal85:#00d9cc;--color-teal100:#e8f7f6;--color-tealDarker:#004d48;--color-tealDark:#008078;--color-teal:#009990;--color-tealLight:#95d5d2;--color-tealLightest:#e8f7f6;--color-coralDarker:#6c000e;--color-coralDark:#901424;--color-coral:#ef4056;--color-coralLight:#f9bfd1;--color-coralLightest:#fdf2f5;--color-amberDarker:#b24000;--color-amberDark:#e55300;--color-amber:#fcb643;--color-amberLight:#ffd25e;--color-amberLightest:#fffbe3;--color-mintDarker:#0b6639;--color-mintDark:#29a668;--color-mint:#00cb77;--color-mintLight:#82ecb7;--color-mintLightest:#c6ffe3;--color-lapisDarker:#00256d;--color-lapisDark:#1649ac;--color-lapis:#3668ff;--color-lapisLight:#95d2ff;--color-lapisLightest:#dceaff;--color-apricotDarker:#9f2600;--color-apricotDark:#d23807;--color-apricot:#f67d6d;--color-apricotLight:#feb69f;--color-apricotLightest:#fdf0ec;--color-irisDarker:#802ac3;--color-irisDark:#9971ef;--color-iris:#c4a5f7;--color-irisLight:#dab5ff;--color-irisLightest:#f2deff;--color-brandPocket:#ef4056;--color-brandFacebook:#3b5998;--color-brandTwitter:#00aced;--color-brandReddit:#ff4500;--color-brandLinkedin:#007bb6;--fontSerif:"Blanco OSF",Garamond,Times,Serif;--fontSerifAlt:"Doyle",Garamond,Times,Serif;--fontSansSerif:"Graphik Web","Helvetica Neue",Helvetica,Arial,Sans-Serif;--fontSizeRootSmall:80%;--fontSizeRootMedium:87.5%;--fontSizeRoot:100%;--fontSize065:0.625rem;--fontSize075:0.75rem;--fontSize085:0.875rem;--fontSize100:1rem;--fontSize125:1.1875rem;--fontSize150:1.4375rem;--fontSize175:1.75rem;--fontSize200:2.0625rem;--fontSize250:2.5rem;--fontSize300:3rem;--spacing025:0.25rem;--spacing050:0.5rem;--spacing075:0.75rem;--spacing100:1rem;--spacing150:1.5rem;--spacing250:2.5rem;--spacing400:4rem;--spacing650:6.5rem;--size025:0.25rem;--size050:0.5rem;--size075:0.75rem;--size100:1rem;--size125:1.25rem;--size150:1.5rem;--size200:2rem;--size250:2.5rem;--size300:3rem;--size400:4rem;--size500:5rem;--zIndexRaised:3;--zIndexHeader:5;--zIndexTooltip:10;--zIndexModalShade:20;--zIndexModal:21;--zIndexColorModePicker:30;--borderStyle:1px solid var(--color-formFieldBorder);--borderRadius:4px;--dividerStyle:1px solid var(--color-dividerTertiary);--raisedCanvas:0 2px 12px rgba(0,0,0,.08);--itemActionLight:0 3px 8px rgba(0,0,0,.1);--itemActionsDark:0 3px 8px rgba(0,0,0,.4);--easingAccelerate:cubic-bezier(0.4,0,1,1);--easingDecelerate:cubic-bezier(0,0,0.2,1);--easingStandard:cubic-bezier(0.4,0,0.2,1);--uiControlsDurationEnterMS:100ms;--uiControlsDurationExitMS:50ms;--dialogsDurationEnterMS:150ms;--dialogsDurationExitMS:75ms;--navDrawerDurationEnterMS:250ms;--navDrawerDurationExitMS:200ms;--selectDownArrowLight:url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%22292.4%22%20height=%22292.4%22%3E%3Cpath%20fill=%22%23000000%22%20d=%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22/%3E%3C/svg%3E");--selectDownArrowDark:url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%22292.4%22%20height=%22292.4%22%3E%3Cpath%20fill=%22%23FFFFFF%22%20d=%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22/%3E%3C/svg%3E");--checkboxCheckMarkLight:url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width=%2216%22%20height=%2213%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill-rule=%22evenodd%22%20clip-rule=%22evenodd%22%20d=%22M4.635%2012.175L1.095%209.21a1.5%201.5%200%20011.927-2.3l2.49%202.087%207.45-7.962a1.5%201.5%200%20012.191%202.05l-8.391%208.968a1.5%201.5%200%2001-2.126.123z%22%20fill=%22%23FFFFFF%22/%3E%3C/svg%3E");--checkboxCheckMarkColor:url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width=%2216%22%20height=%2213%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill-rule=%22evenodd%22%20clip-rule=%22evenodd%22%20d=%22M4.635%2012.175L1.095%209.21a1.5%201.5%200%20011.927-2.3l2.49%202.087%207.45-7.962a1.5%201.5%200%20012.191%202.05l-8.391%208.968a1.5%201.5%200%2001-2.126.123z%22%20fill=%22%23008078%22/%3E%3C/svg%3E");--checkboxCheckMarkHover:url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width=%2216%22%20height=%2213%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20fill-rule=%22evenodd%22%20clip-rule=%22evenodd%22%20d=%22M4.635%2012.175L1.095%209.21a1.5%201.5%200%20011.927-2.3l2.49%202.087%207.45-7.962a1.5%201.5%200%20012.191%202.05l-8.391%208.968a1.5%201.5%200%2001-2.126.123z%22%20fill=%22%23004D48%22/%3E%3C/svg%3E");--crossIconColor:url("data:image/svg+xml;charset=US-ASCII,%20%3Csvg%20width=%2212%22%20height=%2212%22%20viewBox=%220%200%2012%2012%22%20fill=%22none%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20d=%22M2.36369%200.405544C1.82296%20-0.135181%200.94627%20-0.135181%200.405544%200.405544C-0.135181%200.94627%20-0.135181%201.82296%200.405544%202.36369L4.04186%206L0.405544%209.63631C-0.135181%2010.177%20-0.135181%2011.0537%200.405544%2011.5945C0.946271%2012.1352%201.82296%2012.1352%202.36369%2011.5945L6%207.95814L9.63631%2011.5945C10.177%2012.1352%2011.0537%2012.1352%2011.5945%2011.5945C12.1352%2011.0537%2012.1352%2010.177%2011.5945%209.63631L7.95814%206L11.5945%202.36369C12.1352%201.82296%2012.1352%200.94627%2011.5945%200.405544C11.0537%20-0.135181%2010.177%20-0.135181%209.63631%200.405544L6%204.04186L2.36369%200.405544Z%22%20fill=%22%23737373%22/%3E%3C/svg%3E");--crossIconHover:url("data:image/svg+xml;charset=US-ASCII,%20%3Csvg%20width=%2212%22%20height=%2212%22%20viewBox=%220%200%2012%2012%22%20fill=%22none%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cpath%20d=%22M2.36369%200.405544C1.82296%20-0.135181%200.94627%20-0.135181%200.405544%200.405544C-0.135181%200.94627%20-0.135181%201.82296%200.405544%202.36369L4.04186%206L0.405544%209.63631C-0.135181%2010.177%20-0.135181%2011.0537%200.405544%2011.5945C0.946271%2012.1352%201.82296%2012.1352%202.36369%2011.5945L6%207.95814L9.63631%2011.5945C10.177%2012.1352%2011.0537%2012.1352%2011.5945%2011.5945C12.1352%2011.0537%2012.1352%2010.177%2011.5945%209.63631L7.95814%206L11.5945%202.36369C12.1352%201.82296%2012.1352%200.94627%2011.5945%200.405544C11.0537%20-0.135181%2010.177%20-0.135181%209.63631%200.405544L6%204.04186L2.36369%200.405544Z%22%20fill=%22%23404040%22/%3E%3C/svg%3E")}
+/* TYPOGRAPHY --------------------------------------------- */
+:root{font-size:var(--fontSizeRoot)}
+body{background-color:var(--color-canvas);color:var(--color-textPrimary);font-family:var(--fontSansSerif)}
+.h1,h1{font-size:3rem;line-height:125%;margin:0 0 2.5rem}
+.h2,h2{font-size:2.5rem}
+.h2,.h3,h2,h3{line-height:120%;margin:0 0 1.5rem}
+.h3,h3{font-size:2rem}
+.h4,h4{font-size:1.75rem;line-height:128%;margin:0 0 1.5rem}
+.h5,h5{font-size:1.5rem;line-height:122%}
+.h5,.h6,h5,h6{margin:0 0 1rem}
+.h6,h6{font-size:1.25rem;line-height:126%}
+ol,p,ul{font-size:1.25rem;margin:0 0 1.5rem}
+ol,ul{padding:0 0 0 1.5em}
+/* BASIC ELEMENTS --------------------------------------------- */
+form{font-family:var(--fontSansSerif)}
+legend{border-bottom:1px solid var(--color-formFieldBorder);display:block;font-size:var(--fontSize085);font-weight:700;margin:0 0 var(--spacing150) 0}
+input[type=color],input[type=date],input[type=datetime-local],input[type=email],input[type=month],input[type=number],input[type=password],input[type=search],input[type=tel],input[type=text],input[type=time],input[type=url],input[type=week],select,textarea{-webkit-appearance:none;background:none;border:none;border-radius:var(--borderRadius);box-shadow:0 0 0 1px var(--color-formFieldBorder);color:var(--color-textPrimary);display:block;font-family:var(--fontSansSerif);line-height:160%;outline:none;padding:var(--spacing050) var(--spacing075);width:100%}
+input[type=color]:disabled,input[type=date]:disabled,input[type=datetime-local]:disabled,input[type=email]:disabled,input[type=month]:disabled,input[type=number]:disabled,input[type=password]:disabled,input[type=search]:disabled,input[type=tel]:disabled,input[type=text]:disabled,input[type=time]:disabled,input[type=url]:disabled,input[type=week]:disabled,select:disabled,textarea:disabled{opacity:.5;pointer-events:none}
+input[type=color]:hover:enabled,input[type=date]:hover:enabled,input[type=datetime-local]:hover:enabled,input[type=email]:hover:enabled,input[type=month]:hover:enabled,input[type=number]:hover:enabled,input[type=password]:hover:enabled,input[type=search]:hover:enabled,input[type=tel]:hover:enabled,input[type=text]:hover:enabled,input[type=time]:hover:enabled,input[type=url]:hover:enabled,input[type=week]:hover:enabled,select:hover:enabled,textarea:hover:enabled{box-shadow:0 0 0 1px var(--color-formFieldBorderHover)}
+input[type=color]:focus:enabled,input[type=date]:focus:enabled,input[type=datetime-local]:focus:enabled,input[type=email]:focus:enabled,input[type=month]:focus:enabled,input[type=number]:focus:enabled,input[type=password]:focus:enabled,input[type=search]:focus:enabled,input[type=tel]:focus:enabled,input[type=text]:focus:enabled,input[type=time]:focus:enabled,input[type=url]:focus:enabled,input[type=week]:focus:enabled,select:focus:enabled,textarea:focus:enabled{box-shadow:0 0 0 2px var(--color-actionPrimary)}
+input[type=search]::-webkit-search-cancel-button,input[type=search]::-webkit-search-decoration,input[type=search]::-webkit-search-results-button,input[type=search]::-webkit-search-results-decoration{-webkit-appearance:none;display:none}
+select:-moz-focusring{color:transparent;text-shadow:0 0 0 var(--color-textPrimary)}
+label{cursor:pointer;font-family:var(--fontSansSerif)}
+label.block{align-items:center;display:flex}
+label>input[type=checkbox],label>input[type=radio]{cursor:pointer;margin:0 .725rem 0 0}
+input[type=checkbox]+label,input[type=radio]+label{display:inline-block;margin:0 0 0 var(--spacing075);vertical-align:middle}
+input[type=radio]{-webkit-appearance:none;-moz-appearance:none;appearance:none;background:var(--color-canvas);border:2px solid var(--color-formFieldBorder);border-radius:50%;height:var(--size150);margin:var(--size050) 0 var(--size050);outline:none;transition:border 50ms cubic-bezier(.4,0,.2,1),background 50ms cubic-bezier(.4,0,.2,1);vertical-align:middle;width:var(--size150)}
+input[type=radio]+label{cursor:pointer;display:inline-block;margin:var(--size050) 0 var(--size050);min-height:24px;padding:0 24px;position:relative;vertical-align:bottom}
+input[type=radio]+label:after,input[type=radio]+label:before{border-radius:50%;content:"";position:absolute;transition:all 50ms ease;transition-property:transform,border-color}
+input[type=radio]+label:before{border:2px solid var(--color-formFieldBorder);height:24px;left:-12px;top:0;width:24px}
+input[type=radio]+label:after{background:var(--color-actionPrimary);height:14px;left:-7px;top:5px;transform:scale(0);width:14px}
+input[type=radio]:focus{outline:2px solid var(--color-actionPrimary);outline-offset:2px}
+input[type=radio]:hover:enabled,input[type=radio]:hover:enabled+label:before{border-color:var(--color-actionPrimaryHover)}
+input[type=radio]:disabled+label{opacity:.5}
+input[type=radio]:disabled:hover+label,input[type=radio]:disabled:hover+label:before{cursor:not-allowed}
+input[type=radio]:checked{background-color:var(--color-actionPrimary);box-shadow:inset 0 0 0 2px var(--color-canvas)}
+input[type=radio]:checked,input[type=radio]:checked+label:before{border-color:var(--color-actionPrimary)}
+input[type=radio]:checked+label:after{transform:scale(1)}
+input[type=radio]:checked:active:enabled+label:before,input[type=radio]:checked:hover:enabled+label:before{border-color:var(--color-actionPrimaryHover)}
+input[type=radio]:checked:active:enabled+label:after,input[type=radio]:checked:hover:enabled+label:after{background:var(--color-actionPrimaryHover)}
+input[type=radio]:focus+label:before{box-shadow:0 0 0 2px var(--color-canvas),0 0 0 4px var(--color-formFieldFocusLabel)}
+input[type=checkbox]{-webkit-appearance:none;-moz-appearance:none;appearance:none;background:var(--color-canvas);border:2px solid var(--color-formFieldBorder);border-radius:4px;height:var(--size150);margin:var(--size050) 0 var(--size050);outline:none;transition:border 50ms cubic-bezier(.4,0,.2,1),background 50ms cubic-bezier(.4,0,.2,1);vertical-align:middle;width:var(--size150)}
+input[type=checkbox]+label{width:calc(100% - var(--spacing075) - var(--size150))}
+input[type=checkbox]:hover{border:2px solid var(--color-actionPrimary)}
+input[type=checkbox]:active{border:2px solid var(--color-actionPrimaryHover)}
+input[type=checkbox]:before{content:var(--checkboxCheckMarkLight);display:block;line-height:normal;opacity:0;text-align:center;transform:scale(0);transition:opacity .1s cubic-bezier(.4,0,.2,1),transform .1s cubic-bezier(.4,0,.2,1)}
+input[type=checkbox]:checked{background:var(--color-actionPrimary);border:2px solid var(--color-actionPrimary)}
+input[type=checkbox]:checked:before{opacity:1;transform:scale(1)}
+input[type=checkbox]:checked:hover{background:var(--color-actionPrimaryHover);border:2px solid var(--color-actionPrimaryHover)}
+input[type=checkbox]:focus{box-shadow:0 0 0 2px var(--color-canvas),0 0 0 4px var(--color-formFieldFocusLabel)}
+input[type=checkbox]:disabled,input[type=checkbox]:disabled+label,input[type=checkbox]:disabled:checked,input[type=checkbox]:disabled:checked+label{opacity:.5;pointer-events:none}
+input.toggle[type=checkbox]{-webkit-appearance:none;-moz-appearance:none;appearance:none;background:var(--color-toggleOff);border:none;border-radius:18px;color:var(--color-actionPrimary);cursor:pointer;height:36px;margin:.25 0;outline:none;transition:background 50ms cubic-bezier(.4,0,.2,1);vertical-align:middle;width:64px}
+input.toggle[type=checkbox]+label{width:auto}
+input.toggle[type=checkbox]:active,input.toggle[type=checkbox]:hover{background-color:var(--color-toggleOffHover);border:none}
+input.toggle[type=checkbox]:active:before,input.toggle[type=checkbox]:hover:before{content:var(--crossIconHover)}
+input.toggle[type=checkbox]:before{align-items:center;background-color:var(--color-canvas);border-radius:18px;content:var(--crossIconColor);display:flex;height:32px;justify-content:center;line-height:normal;margin:2px;opacity:1;transform:translateX(0);transition:transform .15s cubic-bezier(.4,0,.2,1);width:32px}
+input.toggle[type=checkbox]:checked{background:var(--color-actionPrimary);border:none;color:var(--color-actionPrimary)}
+input.toggle[type=checkbox]:checked:before{content:var(--checkboxCheckMarkColor);opacity:1;transform:translateX(28px)}
+input.toggle[type=checkbox]:checked:hover{background:var(--color-actionPrimaryHover);border:none}
+input.toggle[type=checkbox]:checked:hover:before{content:var(--checkboxCheckMarkHover)}
+input.toggle[type=checkbox]:focus{box-shadow:0 0 0 2px var(--color-canvas),0 0 0 4px var(--color-formFieldFocusLabel)}
+input.toggle[type=checkbox]:disabled,input.toggle[type=checkbox]:disabled+label,input.toggle[type=checkbox]:disabled:checked,input.toggle[type=checkbox]:disabled:checked+label{opacity:.5;pointer-events:none}
+select{-webkit-appearance:none;-moz-appearance:none;appearance:none;background-image:var(--selectDownArrowLight);background-position:right .7rem top 50%;background-repeat:no-repeat;background-size:11px auto;padding-right:1.725rem}
+.colormode-dark select{background-image:var(--selectDownArrowDark)}
+option{color:var(--color-textPrimary)}
+.colormode-dark option{color:var(--color-canvas)}
+a{color:inherit;text-decoration:underline;transition:color .1s ease-out}
+@media (hover:hover) and (pointer:fine){a:hover{color:var(--color-textLinkHover)}}
+a.button,button,input[type=button],input[type=reset],input[type=submit]{background-color:var(--color-actionPrimary);border:none;border-radius:var(--borderRadius);color:var(--color-actionPrimaryText);display:inline-block;font-family:var(--fontSansSerif);font-size:1rem;line-height:110%;padding:.75rem;text-decoration:none;white-space:nowrap}
+a.button:hover,button:hover,input[type=button]:hover,input[type=reset]:hover,input[type=submit]:hover{background-color:var(--color-actionPrimaryHover);text-decoration:none}
+a.button:focus,button:focus,input[type=button]:focus,input[type=reset]:focus,input[type=submit]:focus{outline:1px auto var(--color-actionFocus);outline-offset:3px}
+a.button[data-tooltip],button[data-tooltip],input[type=button][data-tooltip],input[type=reset][data-tooltip],input[type=submit][data-tooltip]{border:2px solid var(--color-canvas)}
+a.button[data-tooltip]:focus,button[data-tooltip]:focus,input[type=button][data-tooltip]:focus,input[type=reset][data-tooltip]:focus,input[type=submit][data-tooltip]:focus{box-shadow:0 0 0 2px var(--color-actionFocus);outline:none}
+a.button.large,button.large,input[type=button].large,input[type=reset].large,input[type=submit].large{font-size:1.25rem;padding:1rem}
+a.button.small,button.small,input[type=button].small,input[type=reset].small,input[type=submit].small{font-size:.85rem;padding:.75rem}
+.colormode-dark a.button,.colormode-dark button,.colormode-dark input[type=button],.colormode-dark input[type=reset],.colormode-dark input[type=submit]{font-weight:500}
+a.button.secondary,button.secondary,input[type=button].secondary,input[type=reset].secondary,input[type=submit].secondary{background-color:var(--color-canvas);border:1px solid var(--color-actionSecondary);color:var(--color-actionSecondaryText)}
+a.button.secondary:hover,button.secondary:hover,input[type=button].secondary:hover,input[type=reset].secondary:hover,input[type=submit].secondary:hover{background-color:var(--color-actionSecondaryHover);color:var(--color-actionSecondaryHoverText)}
+a.button.brand,button.brand,input[type=button].brand,input[type=reset].brand,input[type=submit].brand{background-color:var(--color-actionBrand);color:var(--color-actionBrandText)}
+a.button.brand:hover,button.brand:hover,input[type=button].brand:hover,input[type=reset].brand:hover,input[type=submit].brand:hover{background-color:var(--color-actionBrandHover)}
+a.button.text,button.text,input[type=button].text,input[type=reset].text,input[type=submit].text{background-color:transparent;color:var(--color-textPrimary)}
+a.button.text:hover,button.text:hover,input[type=button].text:hover,input[type=reset].text:hover,input[type=submit].text:hover{background-color:transparent;color:var(--color-textLinkHover);text-decoration:underline}
+a.button.text:focus,button.text:focus,input[type=button].text:focus,input[type=reset].text:focus,input[type=submit].text:focus{outline:none;outline-offset:3px}
+a.button+a.button,a.button+button,a.button+input[type=button],a.button+input[type=reset],a.button+input[type=submit],button+a.button,button+button,button+input[type=button],button+input[type=reset],button+input[type=submit],input[type=button]+a.button,input[type=button]+button,input[type=button]+input[type=button],input[type=button]+input[type=reset],input[type=button]+input[type=submit],input[type=reset]+a.button,input[type=reset]+button,input[type=reset]+input[type=button],input[type=reset]+input[type=reset],input[type=reset]+input[type=submit],input[type=submit]+a.button,input[type=submit]+button,input[type=submit]+input[type=button],input[type=submit]+input[type=reset],input[type=submit]+input[type=submit]{margin-right:1rem}
+#ot-sdk-btn.optanon-show-settings,#ot-sdk-btn.ot-sdk-show-settings{align-items:center;background-color:transparent;border:none;cursor:pointer;display:inline-flex;font-family:inherit;font-size:1rem;font-weight:400;justify-content:center;line-height:1.5;padding:0}
+@media screen and (-ms-high-contrast:active){#ot-sdk-btn.optanon-show-settings,#ot-sdk-btn.ot-sdk-show-settings{border:2px solid}}
+#ot-sdk-btn.optanon-show-settings,#ot-sdk-btn.ot-sdk-show-settings{color:var(--color-textPrimary);text-decoration:underline}
+#ot-sdk-btn.optanon-show-settings:hover,#ot-sdk-btn.ot-sdk-show-settings:hover{color:var(--color-textLinkHover)}
+#ot-sdk-btn.optanon-show-settings:focus,#ot-sdk-btn.ot-sdk-show-settings:focus{outline:none}
+/* APP FONTS --------------------------------------------- */
+@font-face{font-family:Blanco OSF;src:url(https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Regular.7d5a8216b7607638e81feb748552a702.woff2)}
+@font-face{font-family:Blanco OSF;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Bold.5597c92771d64715fcfc7af63ba976e9.woff2)}
+@font-face{font-family:Blanco OSF;font-style:italic;src:url(https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-Italic.5e84440eca9d20d6c8311bd3bd6af473.woff2)}
+@font-face{font-family:Blanco OSF;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/BlancoOSFWeb-BoldItalic.45e2653f7bf12f75c2f9e8cef5e95e64.woff2)}
+@font-face{font-family:Doyle;font-weight:400;src:url(https://assets.getpocket.com/web-ui/assets/Doyle-Regular.96ab1443bd74e896395776fc10e78857.woff2)}
+@font-face{font-family:Doyle;font-style:italic;font-weight:400;src:url(https://assets.getpocket.com/web-ui/assets/Doyle-RegularItalic.e7af5c11daccb053aa0244f7a3e74ebf.woff2)}
+@font-face{font-family:Doyle;font-weight:500;src:url(https://assets.getpocket.com/web-ui/assets/Doyle-Medium.eb6ee0eb205e8467cb3b0e61191217b2.woff2)}
+@font-face{font-family:Doyle;font-style:italic;font-weight:500;src:url(https://assets.getpocket.com/web-ui/assets/Doyle-MediumItalic.10520e4820b03f63912a9b52ba5aae7a.woff2)}
+@font-face{font-family:Graphik Web;font-weight:100;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Thin-Web.f68162edaf17e6d6222ab9da5ee6a3ee.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:100;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-ThinItalic-Web.0d830398baa16b5b118e9c3a72544630.woff2)}
+@font-face{font-family:Graphik Web;font-weight:200;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Extralight-Web.3e7d8320e82a4ac557bffb30f49a7dd2.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:200;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-ExtralightItalic-Web.e2021e99b9b03e623fb707081f647e11.woff2)}
+@font-face{font-family:Graphik Web;font-weight:300;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Light-Web.4389379ad479dec8e9013bda556ef683.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:300;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-LightItalic-Web.65c8f8e7f2f448733fe4393d0967fa8b.woff2)}
+@font-face{font-family:Graphik Web;font-weight:400;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Regular-Web.e05a3b2ff4a3813954bcf8bdb83f9804.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:400;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-RegularItalic-Web.d12ea36eea34954d9fd7dee0ac29640c.woff2)}
+@font-face{font-family:Graphik Web;font-weight:500;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Medium-Web.c28abeb53c5265642e173cb1f81e8091.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:500;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-MediumItalic-Web.e983ce64531b413c98468b4d6c8a13da.woff2)}
+@font-face{font-family:Graphik Web;font-weight:600;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Semibold-Web.1e9ac78e3efd08db3b5db4380e3a1e6f.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:600;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-SemiboldItalic-Web.876e8402cf5eabe6b470184b3a9a99f9.woff2)}
+@font-face{font-family:Graphik Web;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Bold-Web.f9055a490bbbea456422bc02fde65dbd.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-BoldItalic-Web.97ee2ed109056dd42d1c56779c9f17ad.woff2)}
+@font-face{font-family:Graphik Web;font-weight:800;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Black-Web.a525aba1cce162a75f23ba5232bafe71.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:800;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-BlackItalic-Web.e417d4a1935480005c401445a708b71c.woff2)}
+@font-face{font-family:Graphik Web;font-weight:900;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-Super-Web.f16672fba11f8f3c5422665538f11733.woff2)}
+@font-face{font-family:Graphik Web;font-style:italic;font-weight:900;src:url(https://assets.getpocket.com/web-ui/assets/Graphik-SuperItalic-Web.bf26f31b291983c02f78313e9b32c394.woff2)}
+/* READER FONTS --------------------------------------------- */
+@font-face{font-family:IdealSans;src:url(https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Book_Web.8ceb4de0789288847af513bd51c5818a.woff2)}
+@font-face{font-family:IdealSans;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/IdealSansSSm-BookItalic_Web.e3cf9a006e02acd2311610854754c42b.woff2)}
+@font-face{font-family:IdealSans;font-style:italic;src:url(https://assets.getpocket.com/web-ui/assets/IdealSansSSm-Semibold_Web.b23b3824fab9ab4dc8006a6f24423b0f.woff2)}
+@font-face{font-family:IdealSans;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/IdealSansSSm-SemiboldItalic_Web.c851e377c22a9cf75b8b20ab0a388038.woff2)}
+@font-face{font-family:Inter;src:url(https://assets.getpocket.com/web-ui/assets/Inter-Regular.bcdeb499f86c03ab9093fe49b5c795ae.woff2)}
+@font-face{font-family:Inter;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Inter-Italic.2b168e564b4ccdcac9e17b648d9f41b0.woff2)}
+@font-face{font-family:Inter;font-style:italic;src:url(https://assets.getpocket.com/web-ui/assets/Inter-Bold.fe38e3f307fcbac1a801c0c38dff56ef.woff2)}
+@font-face{font-family:Inter;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Inter-BoldItalic.6d8374eb1ad9557adf0daf03048adcc9.woff2)}
+@font-face{font-family:Sentinel;src:url(https://assets.getpocket.com/web-ui/assets/Sentinel-Book_Web.2a0c49d105a76fdcf8843ae4912732d5.woff2)}
+@font-face{font-family:Sentinel;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Sentinel-BookItalic_Web.9f137203ba87748d9f8a9239729b065a.woff2)}
+@font-face{font-family:Sentinel;font-style:italic;src:url(https://assets.getpocket.com/web-ui/assets/Sentinel-Semibold_Web.f3cd3775fc8ca441f3694632cdce03da.woff2)}
+@font-face{font-family:Sentinel;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Sentinel-SemiboldItalic_Web.434b7971453df9b22c5cdf4c60f994e2.woff2)}
+@font-face{font-family:Tiempos;src:url(https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Regular.bf6dfa623745f8f9be2c9306dd445f99.woff2)}
+@font-face{font-family:Tiempos;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-RegularItalic.c7b3f3d417c54b9cf7eb7026b9eff8af.woff2)}
+@font-face{font-family:Tiempos;font-style:italic;src:url(https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-Semibold.7e0dadfec14fed4ca5dd26b8ff3b7265.woff2)}
+@font-face{font-family:Tiempos;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/TiemposTextWeb-SemiboldItalic.694d22d08e25711bb9f3ceb9b78f1e7f.woff2)}
+@font-face{font-family:Whitney;src:url(https://assets.getpocket.com/web-ui/assets/Whitney-Book_Web.98aad5d22b5244dd121c379f3cea2230.woff2)}
+@font-face{font-family:Whitney;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Whitney-BookItal_Web.80efdde5b097eda872e1754487ce68fc.woff2)}
+@font-face{font-family:Whitney;font-style:italic;src:url(https://assets.getpocket.com/web-ui/assets/Whitney-Semibld_Web.de2dee03c81082edf5341031656ea505.woff2)}
+@font-face{font-family:Whitney;font-style:italic;font-weight:700;src:url(https://assets.getpocket.com/web-ui/assets/Whitney-SemibldItal_Web.fdd7d75fa8fa59d56cc3c402c5bccb55.woff2)}
+/* BRAZE STYLES --------------------------------------------- */
+.ab-iam-root .ab-in-app-message.ab-background{background-color:var(--color-canvas)!important;border:1px solid rgba(0,0,0,.12)!important;border-radius:var(--borderRadius)!important;box-shadow:0 8px 24px rgba(0,0,0,.12)!important}
+.ab-iam-root .ab-message-text{color:var(--color-textPrimary)!important;font-family:var(--fontSansSerif)!important;font-weight:400!important}
+.ab-iam-root .ab-close-button svg path{fill:var(--color-textPrimary)!important}
+.ab-iam-root .ab-close-button:hover svg path{fill:var(--color-textLinkHover)!important}

--- a/static/css/mylist/detail/sidebar.css
+++ b/static/css/mylist/detail/sidebar.css
@@ -1,0 +1,54 @@
+.main {
+    display: flex;
+}
+
+.content {
+    position: relative;
+    width: 100%;
+    transition:all .3s;
+}
+
+.content.on {
+    width: 80%;
+    transition:all .3s;
+}
+
+.side-area {
+    height: 100vh;
+    background-color: #dddd;
+    transition:all .3s;
+    border-right: 1px solid #bbb;
+    box-shadow: 2px 0 4px 0 rgb(0 0 0 / 12%);;
+}
+
+.side-area.on {
+    width: 20%;
+    transition:all .3s;
+}
+
+.side-toggle-button {
+    width: 32px;
+    height: 32px;
+    border-radius: 100%;
+    position: absolute;
+    top: 50%;
+    left: 10px;
+    transform: translateY(-50%);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 0 3px 10px rgb(0 0 0 / 15%);;
+}
+
+.side-toggle-button > svg {
+    transform: rotate(180deg);
+    transition:all 0.3s;
+    cursor: pointer;
+}
+
+
+.side-toggle-button.on > svg {
+    transform: rotate(0deg);
+    transition:all 0.3s;
+    cursor: pointer;
+}

--- a/static/js/detail-side-bar.js
+++ b/static/js/detail-side-bar.js
@@ -1,16 +1,13 @@
-const sideToggleButton = document.querySelector('.side-toggle-button')
+import {getElement} from './common.js';
+
+const sideToggleButton = getElement('.side-toggle-button')
 
 sideToggleButton.addEventListener('click', ()=>{
-    const sideArea = document.querySelector('.side-area')
-    const content = document.querySelector('.content')
-    if(!sideArea.classList.contains('on')){
-        sideArea.classList.add('on')
-        sideToggleButton.classList.add('on')
-        content.classList.add('on')
-    } else {
-        sideArea.classList.remove('on')
-        sideToggleButton.classList.remove('on')
-        content.classList.remove('on')
-    }
+    const sideArea = getElement('.side-area')
+    const content = getElement('.content')
+
+    sideArea.classList.toggle('on')
+    sideToggleButton.classList.toggle('on')
+    content.classList.toggle('on')
 
 })

--- a/static/js/detail-side-bar.js
+++ b/static/js/detail-side-bar.js
@@ -2,7 +2,7 @@ import {getElement} from './common.js';
 
 const sideToggleButton = getElement('.side-toggle-button')
 
-sideToggleButton.addEventListener('click', ()=>{
+sideToggleButton.addEventListener('click', () => {
     const sideArea = getElement('.side-area')
     const content = getElement('.content')
 

--- a/static/js/detail-side-bar.js
+++ b/static/js/detail-side-bar.js
@@ -1,0 +1,16 @@
+const sideToggleButton = document.querySelector('.side-toggle-button')
+
+sideToggleButton.addEventListener('click', ()=>{
+    const sideArea = document.querySelector('.side-area')
+    const content = document.querySelector('.content')
+    if(!sideArea.classList.contains('on')){
+        sideArea.classList.add('on')
+        sideToggleButton.classList.add('on')
+        content.classList.add('on')
+    } else {
+        sideArea.classList.remove('on')
+        sideToggleButton.classList.remove('on')
+        content.classList.remove('on')
+    }
+
+})

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -1,0 +1,90 @@
+import {createNode, appendTag, getElement, getCookie} from './common.js';
+
+const root          = document.getElementById("root")
+
+function renderDetail(site) {
+/* 항목의 상새내용을 rendering 하는 함수 */
+
+    const article                       = createNode('article')
+    article.className                   = 'article'
+    appendTag(root, article)
+
+    const header                        = createNode('header')
+    header.className                    = 'h15ky94r'
+    appendTag(article, header)
+
+    const siteTitle                     = createNode('h1')
+    siteTitle.className                 = 'agrq4zn'
+    siteTitle.innerText                 = site.title
+    appendTag(header, siteTitle)
+
+    const writerDiv                     = createNode('div')
+    writerDiv.className                 = 'a1ryita6'
+    appendTag(header, writerDiv)
+
+    const writer                        = createNode('div')
+    writer.className                    = 'a5fas5x'
+    writer.innerText                    = '작성자'
+    appendTag(writerDiv, writer)
+
+    const hostName                      = createNode('span')
+    hostName.className                  = 'awkz85z'
+    hostName.innerText                  = site.host_name
+    appendTag(writer, hostName)
+
+    const originalContainer             = createNode('div')
+    originalContainer.className         = 'p1kdv8ol'
+    appendTag(header, originalContainer)
+
+    const viewOriginal                  = createNode('a')
+    viewOriginal.id                     = 'reader.external-link.view-original'
+    viewOriginal.className              = 'vvqu6of'
+    viewOriginal.href                   = site.url
+    viewOriginal.innerText              = '원본 보기'
+    viewOriginal.setAttribute('data-cy', 'view-original')
+    viewOriginal.setAttribute('target', '_blank')
+    viewOriginal.setAttribute('rel', 'noopener noreferrer')
+    appendTag(originalContainer, viewOriginal)
+
+    const listDiv                       = createNode('div')
+    listDiv.className                   = 't17jcppz'
+    appendTag(originalContainer, listDiv)
+
+    const list                          = createNode('ul')
+    list.className                      = 'list'
+    appendTag(listDiv, list)
+
+    const siteArticle                   = createNode('article')
+    siteArticle.className               = 'c3dczqn'
+    appendTag(article, siteArticle)
+
+    const siteText                      = createNode('div')
+    siteText.innerHTML                  = site.content
+    appendTag(siteArticle, siteText)   
+}
+
+
+function getSiteDetail() {
+
+    let siteId = getElement('#siteid').value;
+
+    // let csrftoken   = getCookie('csrftoken');
+
+    const data = {
+        method: 'GET',
+        headers: {
+            'content-type': 'application/json',
+            // 'X-CSRFToken' : csrftoken,        
+        },
+        // body: JSON.stringify({user : 'user'})
+    }
+
+    fetch(`/api/sites/detail/${siteId}`, data)
+        .then(response => response.json())
+        .then(data => {
+            renderDetail(data)
+        })
+
+}
+getSiteDetail()
+

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -68,15 +68,11 @@ function getSiteDetail() {
 
     let siteId = getElement('#siteid').value;
 
-    // let csrftoken   = getCookie('csrftoken');
-
     const data = {
         method: 'GET',
         headers: {
-            'content-type': 'application/json',
-            // 'X-CSRFToken' : csrftoken,        
+            'content-type': 'application/json',      
         },
-        // body: JSON.stringify({user : 'user'})
     }
 
     fetch(`/api/sites/detail/${siteId}`, data)

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -15,6 +15,12 @@ function renderItem(site) {
     article.id                  = site.id 
     appendTag(root, article)
 
+    const postId                = createNode('input')
+    postId.className            = 'site-id'
+    postId.value                = site.id
+    postId.type                 = 'hidden'
+    appendTag(article, postId)
+
     const item                  = createNode('div')
     item.className              = 'cardWrap'
     appendTag(article, item)
@@ -24,7 +30,7 @@ function renderItem(site) {
     appendTag(item, imgContainer)
 
     const itemLink              = createNode('a')
-    itemLink.href               = site.thumbnail_url
+    itemLink.href               = `/mylist/detail/${site.id}/`           
     appendTag(imgContainer, itemLink)
 
     const img                   = createNode('img')
@@ -39,9 +45,10 @@ function renderItem(site) {
     const titleContainer        = createNode('h2')
     titleContainer.className    = 'title'
     appendTag(content, titleContainer)
-
+    
     const title                 = createNode('a')
     title.innerText             = site.title
+    title.href                  = `/mylist/detail/${site.id}/`  
     appendTag(titleContainer, title)
 
     const details               = createNode('cite')

--- a/templates/mylist/detail/detail.html
+++ b/templates/mylist/detail/detail.html
@@ -1,15 +1,16 @@
 {% load static %}
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <link rel="stylesheet" href="{% static 'css/mylist/detail/detail.css' %}">
-    <link rel="stylesheet" href="{% static 'css/mylist/detail/reset.css' %}">
-    <link rel="stylesheet" href="{% static 'css/mylist/detail/sidebar.css' %}">
-
+    
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        
+        <link rel="stylesheet" href="{% static '/css/mylist/detail/detail.css' %}">
+        <link rel="stylesheet" href="{% static '/css/mylist/detail/sidebar.css' %}">
+        <link rel="stylesheet" href="{% static '/css/mylist/detail/reset.css' %}">
+        
+        <script type="module" src="{% static '/js/detail-side-bar.js' %}"></script>
     <title>Detail</title>
 </head>
 
@@ -19,7 +20,7 @@
             <div class="left-wrapper">
 
                 <div class="backbutton-wrapper header-svg">
-                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" onclick="location.href='{% url 'mylist' %}'">
                         <path
                             d="M12.707 5.707a1 1 0 0 0-1.414-1.414l-7 7a1 1 0 0 0 0 1.414l7 7a1 1 0 0 0 1.414-1.414L7.414 13H19.05c.525 0 .95-.448.95-1s-.425-1-.95-1H7.414l5.293-5.293Z">
                         </path>
@@ -83,6 +84,5 @@
     </main>
 
 </body>
-<script src="{% static 'js/kwak.js' %}"></script>
 
 </html>

--- a/templates/mylist/detail/detail.html
+++ b/templates/mylist/detail/detail.html
@@ -1,0 +1,88 @@
+{% load static %}
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="{% static 'css/mylist/detail/detail.css' %}">
+    <link rel="stylesheet" href="{% static 'css/mylist/detail/reset.css' %}">
+    <link rel="stylesheet" href="{% static 'css/mylist/detail/sidebar.css' %}">
+
+    <title>Detail</title>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-wrapper">
+            <div class="left-wrapper">
+
+                <div class="backbutton-wrapper header-svg">
+                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path
+                            d="M12.707 5.707a1 1 0 0 0-1.414-1.414l-7 7a1 1 0 0 0 0 1.414l7 7a1 1 0 0 0 1.414-1.414L7.414 13H19.05c.525 0 .95-.448.95-1s-.425-1-.95-1H7.414l5.293-5.293Z">
+                        </path>
+                    </svg>
+
+                </div>
+
+            </div>
+            <div class="center-wrapper">
+                <div class="highlight-button header-svg">
+                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M5.512 8.546a3 3 0 0 0-.51 4.195l-.724.723a3.001 3.001 0 0 0-.586 3.415L1.18 19.391a1 1 0 0 0 .39 1.656l4.243 1.414a1 1 0 0 0 1.023-.241l1.098-1.098a3.001 3.001 0 0 0 3.415-.586l.746-.746a3.001 3.001 0 0 0 4.133-.77l6.406-9.15a3 3 0 0 0-.337-3.842l-4.112-4.112a3 3 0 0 0-3.98-.233L5.512 8.546Zm9.932-5.294-8.693 6.863a1 1 0 0 0-.087 1.492l6.4 6.4a1 1 0 0 0 1.526-.134l6.405-9.15a1 1 0 0 0-.112-1.28L16.771 3.33a1 1 0 0 0-1.327-.078ZM6.4 14.172l-.707.707a1 1 0 0 0 0 1.414l2.829 2.828a1 1 0 0 0 1.414 0l.707-.707L6.4 14.172Z">
+                        </path>
+                    </svg>
+                </div>
+                <div class="article-button header-svg">
+                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z">
+                        </path>
+                        <path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"></path>
+                    </svg>
+                </div>
+                <div class="favorite-button header-svg">
+                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M12 1a1 1 0 0 1 .897.557l2.706 5.484 6.051.88a1 1 0 0 1 .555 1.705l-4.38 4.268 1.034 6.027a1 1 0 0 1-1.45 1.054L12 18.13l-5.413 2.845a1 1 0 0 1-1.45-1.054l1.033-6.027-4.379-4.268a1 1 0 0 1 .555-1.706l6.051-.88 2.706-5.483A1 1 0 0 1 12 1Zm0 3.26L9.958 8.397a1 1 0 0 1-.753.548l-4.567.663 3.305 3.221a1 1 0 0 1 .287.885l-.78 4.548 4.085-2.147a1 1 0 0 1 .93 0l4.085 2.147-.78-4.548a1 1 0 0 1 .287-.885l3.305-3.22-4.567-.664a1 1 0 0 1-.753-.548L12 4.26Z">
+                        </path>
+                    </svg>
+                </div>
+                <div class="delete-button header-svg">
+                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M7 5a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4h5a1 1 0 1 1 0 2h-1v11a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7H2a1 1 0 0 1 0-2h5Zm2 0a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2H9ZM5 7h14v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V7Z">
+                        </path>
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M9 10a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1ZM15 10a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z">
+                        </path>
+                    </svg>
+                </div>
+            </div>
+            <div class="right-wrapper">
+
+            </div>
+        </div>
+    </header>
+    <main class="main">
+        <div class="side-area"></div>
+        <div class="content">
+            <p></p>
+            <div class="side-toggle-button">
+                <svg fill="currentColor" viewBox="0 0 24 24" style="width: 24px; height: 24px;"
+                    xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <path fill-rule="evenodd" clip-rule="evenodd"
+                        d="M14.707 4.293a1 1 0 0 1 0 1.414L8.414 12l6.293 6.293a1 1 0 0 1-1.414 1.414l-7-7a1 1 0 0 1 0-1.414l7-7a1 1 0 0 1 1.414 0Z">
+                    </path>
+                </svg>
+            </div>
+        </div>
+    </main>
+
+</body>
+<script src="{% static 'js/kwak.js' %}"></script>
+
+</html>


### PR DESCRIPTION
## What about is this PR? 🔍
- detail에 대한 1차적인 기능 개발
- develop에서 pull받은 후 발생한 충돌 해결
- 항목 detail(상세보기) 화면 추가
- 항목 detail로 이동하는 url 추가
- detail 화면에서 열고 닫을수 있는 사이드 바 추가
- detail 화면 헤더 추가
- detail에서 mylist로 뒤로가기 버튼 활성화
- detail 화면에 site api 연동하여 화면 출력 추가

<br>

## Change Logic 📝

### before
- detail 화면이 존재하지 않음
- detail 화면과 관련된 부가 기능이 존재하지 않음

### after
- detail 화면 개발
- 항목 클릭시 해당 항목에 대한 detail화면으로 이동가능
- 이동한 화면에서 사이드바를 열고 닫을수 있으며 헤더 툴바에서 뒤로가기 버튼 활성화 (뒤로가기는 장고 템플릿 태그로 임시 활성화)
- fetch함수를 통해 site api에서 받아온 정보들을 detail 화면에 출력
- develop에서 받은 pull에 대한 충돌 문제 해결

<br>

## To Reviewers 👂
- 1차적인 기능 확인 코드로 하이라이트 기능과 연결해서 기능이 작동하는것에 대한 테스트를 먼저 할 예정입니다.
- 추후 주석과 코드정리를 차츰 해나갈 예정


<br>

## Screenshot 📷

### detail 화면
<img width="1434" alt="detail" src="https://user-images.githubusercontent.com/107481916/204416937-6e3f420f-a131-4808-a48a-392ffcf065cd.png">

### detail 화면 side bar
<img width="1435" alt="sidebar" src="https://user-images.githubusercontent.com/107481916/204417104-3d490dae-515f-43df-b768-945d73838fba.png">


<br>