### PR TITLE
Edit html about premium, mylist  and Refactor bottom-toolbar.js

### DIFF
--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -1,4 +1,4 @@
-import { createNode, appendTag, getCookie, getElement, setFetchData } from "./common.js"
+import { createNode, appendTag, getElement, setFetchData } from "./common.js"
 import { openModal } from "./modal.js"
 
 function makeFavoriteInToolBar(parentNode, site) {
@@ -66,26 +66,26 @@ function makeTagInToolBar(parentNode, site) {
         - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
     */
 
-    const tagButtonContainer        = createNode('span')
+    const tagButtonContainer            = createNode('span')
     appendTag(parentNode, tagButtonContainer)
 
-    const tagButton                 = createNode('button')
-    tagButton.className             = 'm11fpiro t1221eea pmdugmx d1mp5exd tag'
+    const tagButton                     = createNode('button')
+    tagButton.className                 = 'm11fpiro t1221eea pmdugmx d1mp5exd tag'
     tagButton.setAttribute('data-tooltip', '태그')
     appendTag(tagButtonContainer, tagButton)
 
-    const tagIconContainer          = createNode('span')
-    tagIconContainer.className      = 'i1qqph0t icon'
+    const tagIconContainer              = createNode('span')
+    tagIconContainer.className          = 'i1qqph0t icon'
     appendTag(tagButton, tagIconContainer)
 
-    let tagIconSvgHTML              = `<svg class="tag-icon-svg" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>`
+    let tagIconSvgHTML                  = `<svg class="tag-icon-svg" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>`
     tagIconContainer.insertAdjacentHTML('beforeend', tagIconSvgHTML)
-    const tagIconSvg                = getElement('.tag-icon-svg')
+    const tagIconSvg                    = getElement('.tag-icon-svg')
     
-    let tagIconPathHTMLFirst             = `<path fill-rule="evenodd" clip-rule="evenodd" d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z"></path>`
+    let tagIconPathHTMLFirst            = `<path fill-rule="evenodd" clip-rule="evenodd" d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z"></path>`
     tagIconSvg.insertAdjacentHTML('beforeend', tagIconPathHTMLFirst)
    
-    let tagIconPathHTMLSecond             = `<path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"></path>`
+    let tagIconPathHTMLSecond           = `<path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"></path>`
     tagIconSvg.insertAdjacentHTML('beforeend', tagIconPathHTMLSecond)
 
 }
@@ -95,25 +95,31 @@ function makeDeleteInToolBar(parentNode, site) {
         - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.     
      */
 
-    const deleteButtonContainer     = createNode('span')
+    const deleteButtonContainer         = createNode('span')
     appendTag(parentNode, deleteButtonContainer)
 
-    const deleteButton              = createNode('button')
-    deleteButton.className          = 'm11fpiro t1221eea pmdugmx d1mp5exd delete'
+    const deleteButton                  = createNode('button')
+    deleteButton.className              = 'm11fpiro t1221eea pmdugmx d1mp5exd delete'
     deleteButton.setAttribute('data-tooltip', '삭제')
     appendTag(deleteButtonContainer, deleteButton)
 
-    const deleteIconContainer       = createNode('span')
-    deleteIconContainer.className   = 'i1qqph0t icon'
+    const deleteIconContainer           = createNode('span')
+    deleteIconContainer.className       = 'i1qqph0t icon'
     appendTag(deleteButton, deleteIconContainer)
 
-    const deleteIcon                = createNode('i')
-    deleteIcon.className            = 'fa fa-regular fa-trash fa-lg'
-    appendTag(deleteIconContainer, deleteIcon)
+    let deleteIconSvgHTML               = `<svg class="delete-icon-svg" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>`
+    deleteIconContainer.insertAdjacentHTML('beforeend', deleteIconSvgHTML)
+    const deleteIconSvg                 = getElement('.delete-icon-svg')
+    
+    let deleteIconPathHTMLFirst         = `<path fill-rule="evenodd" clip-rule="evenodd" d="M7 5a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4h5a1 1 0 1 1 0 2h-1v11a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7H2a1 1 0 0 1 0-2h5Zm2 0a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2H9ZM5 7h14v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V7Z"></path>`
+    deleteIconSvg.insertAdjacentHTML('beforeend', deleteIconPathHTMLFirst)
+   
+    let deleteIconPathHTMLSecond        = `<path fill-rule="evenodd" clip-rule="evenodd" d="M9 10a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1ZM15 10a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z"></path>`
+    deleteIconSvg.insertAdjacentHTML('beforeend', deleteIconPathHTMLSecond)
 
     // click 시, modal 창 열기
     deleteButton.addEventListener('click', () => {
-        const article               = document.getElementById(`${site.id}`)
+        const article                   = document.getElementById(`${site.id}`)
         article.classList.toggle('selected')
 
         let modalParam              = {

--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -2,51 +2,69 @@ import { createNode, appendTag, getCookie, getElement } from "./common.js"
 import { openModal } from "./modal.js"
 
 function makeFavoriteInToolBar(parentNode, site) {
-    /* 하단 툴바의 즐겨찾기 버튼 Dom을 만드는 함수 */
+    /* 하단 툴바의 즐겨찾기 버튼 Dom을 만드는 함수 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
-    const favoriteButtonContainer   = createNode('span')
+    const favoriteButtonContainer       = createNode('span')
     appendTag(parentNode, favoriteButtonContainer)
 
-    const favoriteButton            = createNode('button')
-    favoriteButton.className        = site.favorite == false ? 'm11fpiro t1221eea pmdugmx d1mp5exd favorite' : 'm11fpiro t1221eea pmdugmx d1mp5exd favorite active'
+    const favoriteButton                = createNode('button')
+    favoriteButton.className            = site.favorite == false ? 'm11fpiro t1221eea pmdugmx d1mp5exd favorite' : 'm11fpiro t1221eea pmdugmx d1mp5exd favorite active'
     favoriteButton.setAttribute('data-tooltip', site.favorite == false ? '즐겨찾기' : '즐겨찾기 해제')
     appendTag(favoriteButtonContainer, favoriteButton)
 
-    const favoriteIconContainer     = createNode('span')
-    favoriteIconContainer.className = 'i1qqph0t icon'
+    const favoriteIconContainer         = createNode('span')
+    favoriteIconContainer.className     = 'i1qqph0t icon'
     appendTag(favoriteButton, favoriteIconContainer)
 
-    const favoriteIcon              = createNode('i')
-    favoriteIcon.className          = 'fa-regular fa-star fa-lg'
-    appendTag(favoriteIconContainer, favoriteIcon)
+    let favoriteIconSvgHTML             = `<svg class='favorite-icon-svg' fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"aria-hidden="true"></svg>`
+    favoriteIconContainer.insertAdjacentHTML('beforeend', favoriteIconSvgHTML)
+    const favoriteIconSvg               = getElement('.favorite-icon-svg')
+
+    let favoriteIconPathHTML            = '<path fill-rule="evenodd" clip-rule="evenodd" d="M12 1a1 1 0 0 1 .897.557l2.706 5.484 6.051.88a1 1 0 0 1 .555 1.705l-4.38 4.268 1.034 6.027a1 1 0 0 1-1.45 1.054L12 18.13l-5.413 2.845a1 1 0 0 1-1.45-1.054l1.033-6.027-4.379-4.268a1 1 0 0 1 .555-1.706l6.051-.88 2.706-5.483A1 1 0 0 1 12 1Zm0 3.26L9.958 8.397a1 1 0 0 1-.753.548l-4.567.663 3.305 3.221a1 1 0 0 1 .287.885l-.78 4.548 4.085-2.147a1 1 0 0 1 .93 0l4.085 2.147-.78-4.548a1 1 0 0 1 .287-.885l3.305-3.22-4.567-.664a1 1 0 0 1-.753-.548L12 4.26Z"></path>'
+    favoriteIconSvg.insertAdjacentHTML('beforeend', favoriteIconPathHTML)
 
     changeFavoriteValue(favoriteButton, site)
 
 }
 
 function makeCategoryInToolBar(parentNode, site) {
-    /* 하단 툴바의 category button Dom을 만드는 함수 */
+    /* 하단 툴바의 category button Dom을 만드는 함수 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
-    const categoryButtonContainer   = createNode('span')
+    const categoryButtonContainer       = createNode('span')
     appendTag(parentNode, categoryButtonContainer)
 
-    const categoryButton            = createNode('button')
-    categoryButton.className        = 'm11fpiro t1221eea pmdugmx d1mp5exd category'
+    const categoryButton                = createNode('button')
+    categoryButton.className            = 'm11fpiro t1221eea pmdugmx d1mp5exd category'
     categoryButton.setAttribute('data-tooltip', '카테고리')
     appendTag(categoryButtonContainer, categoryButton)
 
-    const categoryIconContainer     = createNode('span')
-    categoryIconContainer.className = 'i1qqph0t icon'
+    const categoryIconContainer         = createNode('span')
+    categoryIconContainer.className     = 'i1qqph0t icon'
     appendTag(categoryButton, categoryIconContainer)
 
-    const categoryIcon              = createNode('i')
-    categoryIcon.className          = 'fa fa-regular fa-folder-open fa-lg'
-    appendTag(categoryIconContainer, categoryIcon)
+    let categoryIconSvgHTML             = '<svg class="category-icon-svg" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>'
+    categoryIconContainer.insertAdjacentHTML('beforeend', categoryIconSvgHTML)
+    const categoryIconSvg               = getElement('.category-icon-svg')
+
+    let categoryIconPathHTMLFirst       = '<path fill-rule="evenodd" clip-rule="evenodd" d="M1 4a2 2 0 0 1 2-2h18a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4Zm2 0v2h18V4H3Z"></path>'
+    categoryIconSvg.insertAdjacentHTML('beforeend', categoryIconPathHTMLFirst)
+    
+    let categoryIconPathHTMLSecond      = '<path fill-rule="evenodd" clip-rule="evenodd" d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V8Zm2 10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8H5v10Z"></path>'
+    categoryIconSvg.insertAdjacentHTML('beforeend', categoryIconPathHTMLSecond)
+    
+    let categoryIconPathHTMLThird       = '<path fill-rule="evenodd" clip-rule="evenodd" d="M15.707 11.293a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 1 1 1.414-1.414L11 14.586l3.293-3.293a1 1 0 0 1 1.414 0Z"></path>'
+    categoryIconSvg.insertAdjacentHTML('beforeend', categoryIconPathHTMLThird)
 
 }
 
 function makeTagInToolBar(parentNode, site) {
-    /* 하단 툴바의 tag button Dom을 만드는 함수 */
+    /* 하단 툴바의 tag button Dom을 만드는 함수
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
     const tagButtonContainer        = createNode('span')
     appendTag(parentNode, tagButtonContainer)
@@ -60,15 +78,22 @@ function makeTagInToolBar(parentNode, site) {
     tagIconContainer.className      = 'i1qqph0t icon'
     appendTag(tagButton, tagIconContainer)
 
+    let tagIconSvgHTML              = `<svg class="tag-icon-svg" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"></svg>`
+    tagIconContainer.insertAdjacentHTML('beforeend', tagIconSvgHTML)
+    const tagIconSvg                = getElement('.tag-icon-svg')
     
-    const tagIcon                   = createNode('i')
-    tagIcon.className               = 'fa-regular fa-hashtag fa-lg'
-    appendTag(tagIconContainer, tagIcon)
+    let tagIconPathHTMLFirst             = `<path fill-rule="evenodd" clip-rule="evenodd" d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z"></path>`
+    tagIconSvg.insertAdjacentHTML('beforeend', tagIconPathHTMLFirst)
+   
+    let tagIconPathHTMLSecond             = `<path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"></path>`
+    tagIconSvg.insertAdjacentHTML('beforeend', tagIconPathHTMLSecond)
 
 }
 
 function makeDeleteInToolBar(parentNode, site) {
-     /* 하단 툴바의 delete button Dom을 만드는 함수 */
+     /* 하단 툴바의 delete button Dom을 만드는 함수 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.     
+     */
 
     const deleteButtonContainer     = createNode('span')
     appendTag(parentNode, deleteButtonContainer)
@@ -106,7 +131,9 @@ function makeDeleteInToolBar(parentNode, site) {
 }
 
 function makeBottomToolbar(parentNode, site) {
-    /*각 항목마다 하단 툴바를 만드는 함수*/
+    /*각 항목마다 하단 툴바를 만드는 함수
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
      // bottom toolbar container - footer
      const footer                   = createNode('footer')
@@ -156,7 +183,9 @@ function makeBottomToolbar(parentNode, site) {
 }
 
 function changeFavoriteValue(favoriteButton, site) {
-    /* 하단 툴바의 즐겨찾기 버튼 상태 변경에 따른 즐겨찾기 목록에 추가 및 제거 */
+    /* 하단 툴바의 즐겨찾기 버튼 상태 변경에 따른 즐겨찾기 목록에 추가 및 제거
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
     favoriteButton.addEventListener('click', () => {
 
@@ -227,7 +256,9 @@ function changeFavoriteValue(favoriteButton, site) {
 }
 
 function deleteSite() {
-    /* DELETE http message를 보내는 함수 */
+    /* DELETE http message를 보내는 함수 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
     const site = getElement('.c18o9ext.grid.hiddenActions.noExcerpt.selected')
     const csrftoken                 = getCookie('csrftoken');

--- a/static/js/bottom-toolbar.js
+++ b/static/js/bottom-toolbar.js
@@ -1,4 +1,4 @@
-import { createNode, appendTag, getCookie, getElement } from "./common.js"
+import { createNode, appendTag, getCookie, getElement, setFetchData } from "./common.js"
 import { openModal } from "./modal.js"
 
 function makeFavoriteInToolBar(parentNode, site) {
@@ -114,7 +114,7 @@ function makeDeleteInToolBar(parentNode, site) {
     // click 시, modal 창 열기
     deleteButton.addEventListener('click', () => {
         const article               = document.getElementById(`${site.id}`)
-        article.classList.add('selected')
+        article.classList.toggle('selected')
 
         let modalParam              = {
                                         func        : deleteSite,
@@ -190,33 +190,19 @@ function changeFavoriteValue(favoriteButton, site) {
     favoriteButton.addEventListener('click', () => {
 
         // 하단 툴바의 즐겨찾기 버튼 활성화 및 즐겨찾기 목록에 추가
-        const csrftoken             = getCookie('csrftoken');
-
         if (favoriteButton.classList.contains('active') == false) {
           
             // PUT: favorite 값 True로 수정
-            const data              = {
-                                        method: 'PUT',
-                                        headers: {
-                                            'content-type': 'application/json',
-                                            'X-CSRFToken' : csrftoken,  
-                                            },
-                                            body: JSON.stringify({
-                                                favorite: true,
-                                            })
-                                      }
-
+            const data              = setFetchData('PUT', {favorite: true})
             fetch(`/api/sites/${site.id}`, data)
             .then(response => {
                 let status          = response.status
 
                 // 하단 툴바의 즐겨찾기 버튼 활성화
                 if (status === 202) {
-                    
-                    favoriteButton.classList.add('active');
+                    favoriteButton.classList.toggle('active');
                     favoriteButton.setAttribute('data-tooltip', '즐겨찾기 해제');
                     console.log("즐겨찾기 목록에 추가했습니다.", data)
-                
                 } return response.json() })
                 .catch(error => console.error('Error:', error))
             }
@@ -224,29 +210,16 @@ function changeFavoriteValue(favoriteButton, site) {
         // 하단 툴바의 즐겨찾기 버튼 비활성화 및 즐겨찾기 목록에서 제거
         else { 
             // PUT: favorite 값 false로 수정
-            const data              = {
-                                        method: 'PUT',
-                                        headers: {
-                                            'content-type': 'application/json',
-                                            'X-CSRFToken' : csrftoken,  
-                                        },
-                                        body: JSON.stringify({
-                                            'favorite': false,
-                                        })
-                                     }
-
+            const data              = setFetchData('PUT', {favorite: false})
             fetch(`/api/sites/${site.id}`, data)
             .then(response => {
-
                 let status          = response.status
 
                 // 하단 툴바의 즐겨찾기 버튼 비활성화
                 if (status === 202) {
-                
-                    favoriteButton.classList.remove('active');
+                    favoriteButton.classList.toggle('active');
                     favoriteButton.setAttribute('data-tooltip', '즐겨찾기');
                     console.log("즐겨찾기 목록에서 제거했습니다.", data)
-                
                 } return response.json() })
                 .catch(error => console.error('Error:', error))
             }
@@ -260,16 +233,8 @@ function deleteSite() {
         - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
     */
 
-    const site = getElement('.c18o9ext.grid.hiddenActions.noExcerpt.selected')
-    const csrftoken                 = getCookie('csrftoken');
-    const data                      = {
-        method: 'DELETE',
-        headers: {
-            'content-type': 'application/json',
-            'X-CSRFToken' : csrftoken,  
-        },
-    }
-    
+    const site                  = getElement('.c18o9ext.grid.hiddenActions.noExcerpt.selected')
+    const data                  = setFetchData('DELETE', '')
     fetch(`/api/sites/${site.id}`, data)
     .then(response => {
         const status                = response.status

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -3,7 +3,9 @@ import {createNode, appendTag, getElement, getCookie} from './common.js';
 const root          = document.getElementById("root")
 
 function renderDetail(site) {
-/* 항목의 상새내용을 rendering 하는 함수 */
+/* 항목의 상새내용을 rendering 하는 함수 
+    - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+*/
 
     const article                       = createNode('article')
     article.className                   = 'article'

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -268,7 +268,9 @@ function mapTags(data) {
 }
 
 function makeActive() {
-    /* side bar의 각 탭을 클릭 시, 활성화하는 함수 */
+    /* side bar의 각 탭을 클릭 시, 활성화하는 함수 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
     
     let i; 
     const sidebar       = document.querySelectorAll('.sv813dg')

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,10 +1,11 @@
-import {createNode, appendTag, insertAfter, getElement, getCookie, getElements, removeElement} from './common.js';
+import {createNode, appendTag, insertAfter, getElement, getElements, removeElement} from './common.js';
 
 let added_tags =[] 
 
 function makeModal(param) {
-    
-    /* modal 창 만들기 */
+    /* modal 창 만들기 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
     const next                      = getElement('#__next')
     next.setAttribute('aria-hidden','true')
@@ -94,7 +95,9 @@ function makeModal(param) {
 }
 
 function openModal(param) {
-    /* Modal 창 열기 */
+    /* Modal 창 열기 
+        - 특정 문자열로 className에 할당되는 값들은 클론코딩으로 가져오는 css를 반영하기 위한 것입니다.
+    */
 
     makeModal(param);
 

--- a/templates/mylist/base.html
+++ b/templates/mylist/base.html
@@ -68,7 +68,11 @@
 
                             <button onclick="" type="click" class="sv813dg" id="categories" data-cy="side-nav-archive">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <i class='fa fa-regular fa-folder-open fa-lg'></i>
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M1 4a2 2 0 0 1 2-2h18a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4Zm2 0v2h18V4H3Z"></path>
+                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V8Zm2 10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8H5v10Z"></path>
+                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M15.707 11.293a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 1 1 1.414-1.414L11 14.586l3.293-3.293a1 1 0 0 1 1.414 0Z"></path>
+                                    </svg>
                                 </span> 카테고리
                             </button>
 
@@ -125,7 +129,10 @@
 
                             <button onclick="location.href='{% url 'tags' %}'" type="click" class="sv813dg tags" id="tags" data-cy="side-nav-all-tags">
                                 <span class="i1qqph0t icon side-nav-icon">
-                                    <i class='fa-regular fa-hashtag fa-lg'></i>
+                                    <svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4a2 2 0 0 1 2-2h6a2 2 0 0 1 1.414.586L20 11.172a4 4 0 0 1 0 5.656L16.828 20a4 4 0 0 1-5.656 0l-8.586-8.586A2 2 0 0 1 2 10V4Zm8 0 8.586 8.586a2 2 0 0 1 0 2.828l-3.172 3.172a2 2 0 0 1-2.828 0L4 10V4h6Z"></path>
+                                        <path d="M9 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"></path>
+                                    </svg>
                                 </span> 모든 태그
                             </button>
                         </nav>

--- a/templates/premium/base.html
+++ b/templates/premium/base.html
@@ -82,7 +82,7 @@
                             <div class="name">Premium</div>
                             <div class="plan">월간 멤버십</div>
                             <div class="price">
-                                ₩5113/월
+                                ₩5,000/월
                             </div>
                         </header>
                         <ul>
@@ -93,7 +93,7 @@
                             <li key="4">무제한 하이라이트</li>
                             <li key="5">프리미엄 폰트</li>
                         </ul>
-                        <button class="gray" type='button' onclick="location.href='{% url 'payment' %}'">
+                        <button class="red order" type='submit'>
                             이 옵션 선택
                         </button>
                     </div>
@@ -199,17 +199,9 @@
             </div>
             <div id="sticky-sister"></div>
             <div class="sales-buttons" id="plans-no-packages">
-                <div class='sale-option annual'>
-                    <div class="discount">25% 할인</div>
-                    <div class="plan">연간 멤버십</div>
-                    <div class="price">₩46104/년</div>
-                    <button class="" data-url="/premium/subscription/new?planId=plan_F9rTIy9B2sA67C">
-                        플랜 선택
-                    </button>
-                </div>
                 <div class='sale-option monthly'>
                     <div class="plan">월간 멤버십</div>
-                    <div class="price">₩5113/월</div>
+                    <div class="price">₩5,000/월</div>
                     <button class="" data-url="/premium/subscription/new?planId=plan_F9rTxr2zS7XY74">
                         플랜 선택
                     </button>


### PR DESCRIPTION
## What about is this PR? 🔍
- html의 특이한 class name에 대한 주석 추가
- sidebar와 bottom-bar의 카테고리, 태그 아이콘을 `<i>` 에서 `<svg>` 로 전환 
- bottom-toolbar.js에  classList.add() 또는 classList.remove() 대신 clssList.toggle() 적용
- setFetchData를 사용하여 fetch에 넣는 data에 대한 코드를 줄임
- 화면 이동하여 카드 정보 입력하는 것 대신에 iamport를 사용하기 때문에 premium button에 연결된 link 삭제 및 클래스 이름 수정

<br>

## Change Logic 📝

### before
- i tag를 사용하여 아이콘 적용
- 조건문과 함께 classList.add()와 remove()를 사용
- 기존에 fetch와 함께 data 그리고, csrf를 별도로 할당받음
- 카드 정보 입력을 받을 것으로 예상되어 별도의 입력 받는 view를 사용

### after
- svg tag로 전환
- classList.toggle을 사용하여 코드를 줄임
- fetch에 넣는 data가 반복되어 만든 setFetch를 사용하여 코드 줄임
- 아임포트를 사용할 시, 카드 정보를 받지 않고 바로 모달창을 띄어 PG 사 결제 연결하기 때문에, payment name을 가진 url 삭제와 template 삭제로 onclick 속성 삭제

<br>

## To Reviewers 👂
- 하루에 하나씩 수정하며 배포를 진행할려고 합니다. 오늘 저녁 먹고 배포 진행


<br>

## Related Issue Tags ✒️
- #41
- #28 

<br>

## Screenshot 📷
- 바뀐 아이콘
<img width="895" alt="Screen Shot 2022-12-01 at 6 28 41 PM" src="https://user-images.githubusercontent.com/78094972/205016554-87a0b46a-ba85-4fd7-ba3f-96ac8ab5547d.png">


<br>