### PR TITLE
ADD: add Simple JWT Token decode logic

### DIFF
--- a/pocket/serializers.py
+++ b/pocket/serializers.py
@@ -2,8 +2,9 @@ from rest_framework_simplejwt.tokens      import RefreshToken
 from rest_framework.serializers           import ModelSerializer
 from rest_framework                       import serializers
 from .models                              import Site, Tag, Payment, User, Highlight
+from config.settings                      import SIMPLE_JWT 
 import jwt,datetime
-from config.settings import SIMPLE_JWT 
+
 class LoginSerializer(serializers.ModelSerializer):
     email                   = serializers.CharField(
         required            = True,

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -100,10 +100,10 @@ function setFetchData(method, body){
     return data
 }
 
-function redirctLogin(response) {
+function redirectLogin(response) {
     /* Server에서 200외의 상태값을 받았을 경우 login페이지로 이동하는 함수 
         - fetch 함수 사용시 response에 아래와 같이 사용
-        - ex : .then(response => redirctLogin(response))
+        - ex : .then(response => redirectLogin(response))
     */
     return response.status == 200 ? response.json() : location.href = '/login'
 }
@@ -120,5 +120,5 @@ export {
     removeAllNode,
     getCookie, 
     setFetchData,
-    redirctLogin,
+    redirectLogin,
 };

--- a/static/js/detail-side-bar.js
+++ b/static/js/detail-side-bar.js
@@ -1,4 +1,4 @@
-import {appendTag, createNode, getElement, removeAllNode, setFetchData, redirctLogin} from './common.js';
+import {appendTag, createNode, getElement, removeAllNode, setFetchData, redirectLogin} from './common.js';
 
 // 전역 변수
 const sideToggleButton                  = getElement('.side-toggle-button')
@@ -103,7 +103,7 @@ function getSideText() {
     }
 
     fetch(`/api/highlights/${siteId}`, data)
-        .then(response => redirctLogin(response))
+        .then(response => redirectLogin(response))
         .then(data => {
             sidePosts(data)
         }) 

--- a/static/js/get-site-list.js
+++ b/static/js/get-site-list.js
@@ -1,4 +1,4 @@
-import {createNode, appendTag, getElement, getElements, removeAllNode, setFetchData, redirctLogin} from './common.js';
+import {createNode, appendTag, getElement, getElements, removeAllNode, setFetchData, redirectLogin} from './common.js';
 import {makeBottomToolbar} from './bottom-toolbar.js';
 import {apiURL} from './api-url.js';
 
@@ -164,7 +164,7 @@ function renderTag(tags) {
         tagButton.onclick    = () => {
 
             fetch(`/api/sites/tags/${tag.id}`)
-                .then(response => redirctLogin(response))
+                .then(response => redirectLogin(response))
                 .then(data     => {
                     mapPosts(data)
                 })
@@ -326,7 +326,7 @@ async function getSiteList(word='') {
 
     // 해당되는 항목들 조회하기  
     await fetch(`${apiURL[apiUrlKey]}?word=${word}`)
-        .then(response => redirctLogin(response))
+        .then(response => redirectLogin(response))
         .then(data => {
             mapPosts(data)
         })
@@ -342,8 +342,8 @@ function getSiteByTagList(word='') {
     // 선택 메뉴 활성화
     makeActive()
 
-    const siteFetch = fetch(`/api/tags/sites?word=${word}`).then(response => redirctLogin(response))
-    const tagFetch  = fetch(`/api/tags`).then(response => redirctLogin(response))
+    const siteFetch = fetch(`/api/tags/sites?word=${word}`).then(response => redirectLogin(response))
+    const tagFetch  = fetch(`/api/tags`).then(response => redirectLogin(response))
                         
     Promise.all([siteFetch, tagFetch])
                         .then(result => {

--- a/templates/user/login.html
+++ b/templates/user/login.html
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="small-12 large-6 columns wide-show">
         <picture class="signup-graphic picture">
-          <source srcset="/static/images/signup/product_mockup2x.9ede6a7b02ceb90f0748e7f8f4b0e5ca.png" media="(min-width: 48em)">
+          <source srcset="{% static 'images/signup/product_mockup2x.9ede6a7b02ceb90f0748e7f8f4b0e5ca.png' %}" media="(min-width: 48em)">
           <source srcset="/i/v4/signup_blank.png 2x">
           <img srcset="/i/v4/signup_blank.png 2x" alt="">
         </picture>


### PR DESCRIPTION
## What about is this PR? 🔍
- login_decorator 함수에 Simple JWT 복호화 로직 추가
- 공통함수 redirctLogin -> redirectLogin 함수명 오타 수정
- Template Tag를 이용한 static 적용
- import 코드 정리



<br>

## Change Logic 📝
### token 복호화
- 전달해주는 키워드 인자 추가 
: pk를 보내주는 함수는 kward 인자가 없으면 login_decorator를 이용할 수 없음 

- 암호화에 사용되는 SIGNING_KEY와 ALGORITHM을 사용하여 복호화 적용 
: payload, 즉 암호화에 사용되었던 데이터 반환

- kwards 인자에 'user_id'값을 담아 return시 매개변수로 반환
: login_decorator를 사용하는 함수는 **kward 인자로 user_id값을 받아올 수 있음

<br>

## To Reviewers 👂
각 CRUD 작업에 있어 user_id를 적용시켜 아래와 같이 적용해주시기 바랍니다.
1. 조회 - 로그인한 user로 등록된 데이터만 조회하는 로직 추가
2. 저장 - 로그인한 user로 데이터 저장하는 로직 추가

3. 수정, 삭제 작업은 해당 항목에 대한 id값 즉, site_id값으로 수정하고 삭제하기 때문에 user_id를 적용할 필요 없을것으로 보임

```python
@login_decorator
def get(self, request, **kward): 

    # 사전에 Token에서 복호화 한 user_id값 사용가능
    user_id = kward['user_id']

    word: str  = request.GET['word']              
    list_qs    = Site.objects.filter(
                    # 사용자 조건 추가
                    Q(user=user_id)|
                    Q(title__contains=word)|
                    Q(host_name__contains=word))  
    serializer = SiteSerializer(list_qs, many=True)

    return Response(serializer.data)
```

단, login_decorator를 사용하는 함수는 **kward를 추가해 주시기 바랍니다.
위의 코드는 예제 이므로 함수마다 다르게 적용해주시기 바랍니다.
