### PR TITLE
Refactor payment logic to apply login functionality using token

### DIFF
--- a/pocket/serializers.py
+++ b/pocket/serializers.py
@@ -2,8 +2,6 @@ from rest_framework_simplejwt.tokens      import RefreshToken
 from rest_framework.serializers           import ModelSerializer
 from rest_framework                       import serializers
 from .models                              import Site, Tag, Payment, User, Highlight
-from config.settings                      import SIMPLE_JWT 
-import jwt,datetime
 
 class LoginSerializer(serializers.ModelSerializer):
     email                   = serializers.CharField(
@@ -63,6 +61,7 @@ class SiteSerializer(ModelSerializer):
     favorite                = serializers.BooleanField(default=False)
     video                   = serializers.BooleanField(default=False)
     
+
     def create(self, validated_data):
         return Site.objects.create(**validated_data)
 
@@ -99,7 +98,7 @@ class PaymentSerializer(ModelSerializer):
 
     class Meta: 
         model = Payment
-        fields = ['user', 'amount', 'payment_id', 'merchant_id', 'works', 'payment_data', 'status', 'type']
+        fields = ['user', 'amount', 'payment_id', 'merchant_id', 'payment_data', 'status', 'type']
 
 
 class HighlightSerializer(serializers.ModelSerializer):
@@ -108,4 +107,4 @@ class HighlightSerializer(serializers.ModelSerializer):
     content_location        = serializers.JSONField(default=dict)
     class Meta:
         model               = Highlight
-        fields              = '__all__'
+        fields              = ['content_text', 'content_location']

--- a/pocket/urls.py
+++ b/pocket/urls.py
@@ -1,4 +1,3 @@
-from django.contrib import admin
 from django.urls import path, include
 
 from pocket.views import (
@@ -19,7 +18,7 @@ from pocket.views import (
     SiteDetailViewAPIView,
     PaymentPassView, 
     PaymentImpStoreView, 
-    MakeStatusFailed,
+    PaymentFailedView,
     HighlightListAPIView,
     HighlightAPIView,
     HighlightPremiumAPIView,
@@ -30,7 +29,7 @@ from pocket.views import (
     SignUpView, 
     PwdHelpView, 
     PremiumView,
-    mylist_view, 
+    SiteView, 
     site_detail_view,
 )
 
@@ -59,7 +58,7 @@ api_patterns = [
     # payment
     path('payment/checkout', PaymentPassView.as_view()),
     path('payment/validation', PaymentImpStoreView.as_view()),
-    path('payment/failure', MakeStatusFailed.as_view()),
+    path('payment/failure', PaymentFailedView.as_view()),
 ]
 
 urlpatterns = [
@@ -72,12 +71,12 @@ urlpatterns = [
     path('login/password/', PwdHelpView.as_view(), name='password'),
 
     # mylist
-    path('mylist/', mylist_view, name='mylist'), 
-    path('mylist/favorites/', mylist_view, name='favorites'), 
-    path('mylist/articles/', mylist_view, name='articles'), 
-    path('mylist/videos/', mylist_view, name='videos'),
-    path('mylist/tags/', mylist_view, name='tags'),
-    path('mylist/highlights/', mylist_view, name='highlights'),
+    path('mylist/', SiteView.as_view(), name='mylist'), 
+    path('mylist/favorites/', SiteView.as_view(), name='favorites'), 
+    path('mylist/articles/', SiteView.as_view(), name='articles'), 
+    path('mylist/videos/', SiteView.as_view(), name='videos'),
+    path('mylist/tags/', SiteView.as_view(), name='tags'),
+    path('mylist/highlights/', SiteView.as_view(), name='highlights'),
 
     # detail
     path('mylist/detail/<int:pk>/', site_detail_view, name='site_detail_view'), 

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -8,8 +8,8 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework          import status
 
+from pocket.serializers import LoginSerializer, SiteSerializer, TagSerializer, HighlightSerializer, PaymentSerializer
 from pocket.decorator   import bulk_decorator, login_decorator, scrap_decorator
-from pocket.serializers import  LoginSerializer, SiteSerializer, TagSerializer, HighlightSerializer
 from pocket.models      import Email, Site, Tag, User, Payment, Highlight
 
 from urllib.parse import urlparse
@@ -553,50 +553,57 @@ class PaymentPassView(APIView):
     생성한 주문번호를 아임포트 결제 창에 전달하는 api
     """
 
-    def post(self, request):
-
-        if not request.user.is_authenticated: 
-            return Response({"authenticated": False}, status=401)
-        
+    @login_decorator
+    def post(self, request, **kwards):
         amount                  = 100 
-        user                    = request.user 
         payment_type            = request.data['type']
-
+        user                    = User.objects.get(id=kwards['user_id'])
+        buyer_email             = Email.objects.get(user=user).email
+        
         try: 
             merchant_id         = Payment.objects.create_new(
                                     user=user, 
                                     amount=amount,
                                     type=payment_type,
                                   )
-        
         except ValueError:
             merchant_id         = None
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         if merchant_id is not None:
             data                = {
-                                    "works": True, 
+                                    "works": True,
+                                    "buyer_name": user.name, 
+                                    "buyer_email": buyer_email,
                                     "merchant_id": merchant_id,
                                     "amount": amount, 
                                   }
             return Response(data, status=status.HTTP_200_OK)
 
-class PaymentImpStoreView(APIView):
+
+class PaymentValidationView(APIView):
+    """
+    입력된 데이터로 결제 정보를 업데이트하고, 유효성 검증을 실행
+    """
+
+    def check_validation(self, payment, data):
+        serializer = PaymentSerializer(payment, data=data, partial=True)
+        if serializer.is_valid(raise_exception=True):    
+            serializer.save()
+
+
+class PaymentImpStoreView(PaymentValidationView):
     """
     아임포트에서 보낸 결제번호를 DB에 저장하는 api
     """
-    
-    def post(self, request):
 
-        if not request.user.is_authenticated: 
-            return Response({"authenticated": False}, status=401)
-
-        user                    = request.user
+    @login_decorator
+    def post(self, request, **kwards):
+        user                    = User.objects.get(id=kwards['user_id'])
         imp_id                  = request.data['imp_id']
         amount                  = request.data['amount']
         merchant_id             = request.data['merchant_id']
         payment_status          = request.data['payment_status']
-        
         payment                 = Payment.objects.get(
                                     user=user,
                                     merchant_id=merchant_id,
@@ -604,41 +611,34 @@ class PaymentImpStoreView(APIView):
                                   )
         
         if payment is not None:
-            payment.payment_id  = imp_id 
-            payment.status      = payment_status
-            payment.save()
-            data                = {'works': True}
-
+            data = {'works': True}
+            user.payment_status = User.PAYMENT_ON
+            user.save()
+            payment_data = {'payment_id' : imp_id, 'status' : payment_status}
+            self.check_validation(payment, data=payment_data)
             return Response(data, status=status.HTTP_200_OK)
-        
         else: 
-            payment.status      = 'failed'
-            payment.save()
-            data                = {'works': False}
-
+            data = {'works': False}
+            self.check_validation(payment, data={'status': 'failed'})
             return Response(data, {'msg':"Can't find a payment object with merchant_id passed"}, status=status.HTTP_400_BAD_REQUEST)
 
 
-class MakeStatusFailed(APIView):
+class PaymentFailedView(PaymentValidationView):
     """
     사용자 변심으로 결제 취소 시, payment의 status를 failed로 변경하는 api
     """
 
-    def post(self, request):
-
+    @login_decorator
+    def post(self, request, **kwards):
         imp_id                      = request.data['imp_id']
         merchant_id                 = request.data['merchant_id']
         payment                     = Payment.objects.get(merchant_id=merchant_id)
         
         if payment is not None: 
-            payment.payment_id      = imp_id
-            payment.status          = 'failed'
-            payment.save()
-            data                    = {'works': True}
-
+            data = {'works': True}
+            payment_data = {'payment_id' : imp_id, 'status' : 'failed'}
+            self.check_validation(payment, data=payment_data)
             return Response(data, status=status.HTTP_200_OK)
-        
         else:
-            data                    = {'works': False}
-            
+            data = {'works': False}
             return Response(data, {'msg':"Can't find a payment object with merchant_id passed"}, status=status.HTTP_400_BAD_REQUEST)

--- a/pocket/views.py
+++ b/pocket/views.py
@@ -90,14 +90,8 @@ def site_detail_view(request, pk):
         return render(request, 'mylist/detail/detail.html', {'pk' : pk})
 
 
-def mylist_view(request):
-    """
-    mylist/base.html과 모든 항목에 대한 조회 view_url을 연결
-    """
-    
-    if request.method == 'GET': 
-
-        return render(request, 'mylist/base.html')
+class SiteView(TemplateView):
+    template_name = 'mylist/base.html'
 
 class HomeView(TemplateView):
     template_name = "common/home.html"

--- a/static/js/call-payment.js
+++ b/static/js/call-payment.js
@@ -6,32 +6,33 @@ window.onload = function () {
     const paymentButton = getElement('.order')
     paymentButton.addEventListener('click', async (e) => {
         const type              = 'card';
-        let merchant_id, amount, payment_info;
+        let buyer_name, buyer_email, merchant_id, amount, payment_info;
         payment_info            = await passPaymentInfo(e, type);
-        [merchant_id, amount]   = payment_info
+        [buyer_name, buyer_email, merchant_id, amount] = payment_info
         if (merchant_id !== '' && merchant_id !== undefined) {
-            console.log('----- request_pay -----')
-            console.log(merchant_id, typeof(merchant_id), amount, typeof(amount))
             IMP.request_pay({
                 pg: 'html5_inicis',
                 merchant_uid: merchant_id,
                 name: 'Devket Premium 서비스',
                 pay_method: 'card',
                 amount: amount,
+                buyer_name : buyer_name,
+                buyer_email : buyer_email
             },
             // 결제창 오픈
             function (response) {
-                console.log('before response.success ---', response)
-                // 결제한 유저의 이름과 이메일 확인하고 결제 버튼 누른 후, 진행되는 로직 
                 if (response.success) {
+                    // 결제한 유저의 이름과 이메일 확인하고 결제 버튼 누른 후, 진행되는 로직 
                     let msg = '결제가 완료되었습니다.';
                     msg += '고유ID : ' + response.imp_uid;
                     msg += '상점 거래ID : ' + response.merchant_uid;
                     msg += '결제 금액 : ' + response.paid_amount;
                     storeImpIdInDB(e, response.merchant_uid, response.imp_uid, response.paid_amount, response.status);
                 } else {
-                    console.log('response.success == false')
-                    makeStatusFailure(e, response.merchant_uid);
+                    if (response.imp_uid) {
+                        // 결제한 유저의 이름과 이메일 확인 후, 사용자 변심으로 결제 창을 닫아 결제 취소되는 로직
+                        makeStatusFailure(e, response.merchant_uid, response.imp_uid);
+                    }
                     let msg = '결제에 실패하였습니다. \n';
                     msg += '에러내용: ' + response.error_msg;
                     alert(msg)
@@ -47,6 +48,8 @@ async function passPaymentInfo(e, type) {
     e.preventDefault(); 
     let merchant_id = ''
     let amount = 0
+    let buyer_name = ''
+    let buyer_email = ''
     const data = setFetchData('POST', {
         amount: amount, 
         type: type
@@ -54,9 +57,11 @@ async function passPaymentInfo(e, type) {
     const response = await fetch(`/api/payment/checkout`, data)
     const result   = await response.json() 
     if (result.works) {
+        buyer_name = result.buyer_name 
+        buyer_email = result.buyer_email
         merchant_id = result.merchant_id
         amount = result.amount
-        return [merchant_id, amount]
+        return [buyer_name, buyer_email, merchant_id, amount]
     } else if (response.status === 401) {
         alert('로그인 해주세요.')
     } else {
@@ -76,7 +81,7 @@ async function storeImpIdInDB(e, merchant_id, imp_id, amount, status) {
     const response = await fetch(`/api/payment/validation`, data)
     const result   = await response.json() 
     if (result.works) {
-        alert('결제가 완료되었습니다.');
+        alert('결제가 완료됐습니다.');
         window.location.href = location.origin+'/mylist/'
     } else {
         if (response.status === 404) {
@@ -90,17 +95,14 @@ async function storeImpIdInDB(e, merchant_id, imp_id, amount, status) {
 }
 
 // transaction 실패 시, DB status 변경 요청하기
-async function makeStatusFailure(e, merchant_id) {
-    console.log('----- makeStatusFailure -----')
+async function makeStatusFailure(e, merchant_id, imp_id) {
     e.preventDefault();
-    const data      = setFetchData('POST', {merchant_id: merchant_id, imp_id: '1bbvds'})
-    console.log('before response', data)
+    const data      = setFetchData('POST', {merchant_id: merchant_id, imp_id: imp_id})
     const response  = await fetch(`/api/payment/failure`, data)
-    console.log('after response', response)
     const result    = await response.json() 
     if (result.works) {
-        console.log('status 변경 완료했습니다.')
+        console.log('status 변경이 완료됐습니다.')
     } else {
-        console.log('status 변경에 실패했습니다.')
+        console.log('status 변경이 실패했습니다.')
     };
 }

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,6 +1,5 @@
 {% load static %}
 <script type="module" src="{% static 'js/profile.js' %}"></script>
-<!-- HEADER  -->
 {% if login == undefined %}
     <header class="pocket-header platform header">
         <nav class="platform-header">

--- a/templates/premium/base.html
+++ b/templates/premium/base.html
@@ -16,8 +16,8 @@
     </head>
 <body class=" premium-page-body ">
 
-    <!-- HEADER -->   
-    {% if login %}
+    <!-- HEADER -->
+    {% if token %}
         {% include "premium/header_after_login.html" %}
     {% else %}
         {% include "premium/header_before_login.html" %}
@@ -71,7 +71,7 @@
                         <ul>
                             <li key="0">저장, 읽기, 시청, 청취</li>
                         </ul>
-                        <button class="gray" data-url="#">
+                        <button class="gray" onclick ="location.href='{% url 'mylist' %}'">
                             목록 보기
                         </button>
                     </div>
@@ -209,7 +209,6 @@
             </div>
         </div>
     </main>
-
 
     <!-- FOOTER -->
     {% include "footer.html" %}


### PR DESCRIPTION
## What about is this PR? 🔍
- token 방식을 적용하고, 사용자 정보를 iamport에 전달하기 위해서 로직을 수정
- 각 payment class에 사용되는 serializer 로직은 별도의 클래스로 만들어 상속받아 사용
   - PaymentValidationView class 생성 


<br>

## Change Logic 📝

### before
- token 방식이 아니어서, if user.is_authenticated 를 통해서 로그인 유무를 확인
  ```python
  if not request.user.is_authenticated: 
              return Response({"authenticated": False}, status=401)
  ```
- 로그인 기능이 연결되지 않았기 때문에, user의 name과 email 정보를 PG 사에 전달 불가능
- 유효성 검증 로직 미적용
- 결제 결과를 사용자의 payment_status에 미반영

### after
- token 방식을 사용했고, 이를 데코레이터로 만들었기 때문에 각 payment class에 적용
  - 기존에 있던 로그인 유무 로직은 삭제 
- 결제 결과에 따라서 payment_status에 결제 완료 반영
- models.py 의 CHOICES 고정 변수들을 보면 [{ }, { }] 로 list 안에 set 데이터 타입을 사용하는 방식과 [( ), ( )]로 list 안에 tuple을 사용하는 방식이 섞여 있었기 때문에, 공식문서를 근거로 전부 tuple로 수정
   - set으로 할 경우, admin에 원하는 방식으로 출력되지 않고, get_display로 보여지는 값도 계속 바뀐다.  
   ```python
    [{PAYMENT_ON, '결제'} .. ]
    
    [(PAYMENT_ON, '결제') .. ]
   ```

- mylist_view FBV를 SiteView CBV로 수정
  -  template_name만 사용하면 되기 때문에, 코드 줄 감소
  - MyListView로 할 경우, ListView를 상속받는 걸로 오해할 수 있어서 SiteView로 결정

- Payment class에서 User 정보와 Email을 가져오는 로직 추가

```python
@login_decorator
def post(self, request, **kwards):
    user  = User.objects.get(id=kwards['user_id'])
    buyer_email = Email.objects.get(user=user).email
```
- 그래서 다음과 같이 data에 추가하여 js에 전달
```python
data  = { "works": True,
               "buyer_name": user.name, 
               "buyer_email": buyer_email,
               "merchant_id": merchant_id,
               "amount": amount, }
        return Response(data, status=status.HTTP_200_OK)
 ```  

- Payment가 Serializer.Field를 거쳐서 저장하기 위해, 그리고 나중에 유효성 검증 로직을 추가 시 적용하기 위해서 PaymentValidationView class 생성


```python
class PaymentValidationView(APIView):
    def check_validation(self, payment, data):
        serializer = PaymentSerializer(payment, data=data, partial=True)
        if serializer.is_valid(raise_exception=True):    
            serializer.save()
```
- 그래서 이전에는 class PaymentImpStoreView(APIView) 였다면, class PaymentImpStoreView(PaymentValidationView) 로 수정 


<br>

## To Reviewers 👂
-  개선 사항이 보이시면 말씀해주세요.

<br>

## Screenshot 📷
- user의 이메일과 이름이 자동적으로 반영
    - 아래 이미지에서 이름이 '*' 인 것은 user의 name이 저장되지 않았기 때문입니다.
<img width="640" alt="Screen_Shot_2022-12-14_at_10 17 08_PM" src="https://user-images.githubusercontent.com/78094972/207795844-fde7cdf4-57a8-409b-8403-f464d23265f9.png">




- 결제 완료 시, user의 payment_status가 1 로 변경
<img width="792" alt="Screen Shot 2022-12-14 at 11 39 26 PM" src="https://user-images.githubusercontent.com/78094972/207795610-8d3e133f-86e4-4e51-b110-3cab961620b5.png">


<br>